### PR TITLE
Fix build environment: upgrade to AGP 9.2.0 / Gradle 9.4.1 for Java 25 compatibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,18 +1,25 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    namespace "jp.or.iidukat.example.pacman"
+    compileSdk 33
+    buildToolsVersion "36.0.0"
 
     defaultConfig {
         applicationId "jp.or.iidukat.example.pacman"
-        minSdkVersion 26
-        targetSdkVersion 33
+        minSdk 26
+        targetSdk 33
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.txt'
         }
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="jp.or.iidukat.example.pacman"
       android:versionCode="1"
       android:versionName="1.0">
 

--- a/app/src/main/java/jp/or/iidukat/example/pacman/GooglePacman.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GooglePacman.java
@@ -64,18 +64,15 @@ public class GooglePacman extends Activity implements OnClickListener {
 
     @Override
     public void onClick(View v) {
-        switch (v.getId()) {
-        case R.id.new_game_button:
+        int id = v.getId();
+        if (id == R.id.new_game_button) {
             transitionToGameView();
             game.startNewGame();
-            break;
-        case R.id.killscreen_button:
+        } else if (id == R.id.killscreen_button) {
             transitionToGameView();
             game.showKillScreen();
-            break;
-        case R.id.exit_button:
+        } else if (id == R.id.exit_button) {
             finish();
-            break;
         }
         
     }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.0'
+        classpath 'com.android.tools.build:gradle:9.2.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Jan 22 01:18:23 JST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- AGP 7.4.0 → 9.2.0、Gradle 7.6 → 9.4.1 にアップグレードし、Java 25 でのビルドエラーを解消
- AGP 9.2.0 の要件に合わせて `buildToolsVersion 36.0.0`、`namespace`、`compileOptions` を追加
- `proguard-android.txt` → `proguard-android-optimize.txt` に変更（AGP 9.2.0 で必須）
- AGP 8.0 以降で R フィールドが非 final になったことに伴い、`switch(R.id)` を `if-else` に変更

## Test plan

- [x] `./gradlew assembleDebug` が BUILD SUCCESSFUL で完了することを確認
- [x] 実機 / エミュレーターでアプリが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)