### PR TITLE
Fix local variable shadowing instance field in GooglePacman#onCreate

### DIFF
--- a/app/src/main/java/jp/or/iidukat/example/pacman/GooglePacman.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GooglePacman.java
@@ -15,7 +15,7 @@ public class GooglePacman extends Activity implements OnClickListener {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         
-        PacmanGame game = initGame();
+        initGame();
         initGameView(game);
         initMainView();
         


### PR DESCRIPTION
## Summary

- `GooglePacman#onCreate` 内のローカル変数 `game` がインスタンスフィールド `this.game` を隠蔽していたため、ローカル変数の宣言を削除
- `initGame()` 内でフィールドへの代入は行われているため動作は変わらないが、意図が明確になり将来のリファクタリング時のバグリスクを解消

## Test plan

- [x] `./gradlew assembleDebug` が BUILD SUCCESSFUL で完了することを確認
- [x] 実機 / エミュレーターでアプリが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)