### PR TITLE
Scale game canvas to fill screen (fullscreen support)

### DIFF
--- a/app/src/main/java/jp/or/iidukat/example/pacman/GameView.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GameView.java
@@ -3,6 +3,7 @@ package jp.or.iidukat.example.pacman;
 import jp.or.iidukat.example.pacman.entity.PacmanCanvas;
 import android.content.Context;
 import android.graphics.Canvas;
+import android.graphics.Matrix;
 import android.os.Handler;
 import android.os.Message;
 import android.util.AttributeSet;
@@ -11,11 +12,13 @@ import android.view.View;
 
 class GameView extends View {
 
-    private static final int CANVAS_WIDTH = 464;
-    private static final int CANVAS_HEIGHT = 168;
-    
-    private int canvasHeight = -1;
-    private int canvasWidth = -1;
+    private static final int GAME_WIDTH = 464;
+    private static final int GAME_HEIGHT = 168;
+
+    private float scale = 1f;
+    private float offsetX = 0f;
+    private float offsetY = 0f;
+    private final Matrix touchTransform = new Matrix();
 
     PacmanGame game;
 
@@ -42,36 +45,45 @@ class GameView extends View {
     public GameView(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
-    
+
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
-        canvasWidth = w > CANVAS_WIDTH ? w : CANVAS_WIDTH;
-        canvasHeight = h > CANVAS_HEIGHT ? h : CANVAS_HEIGHT;
+        scale = Math.min((float) w / GAME_WIDTH, (float) h / GAME_HEIGHT);
+        offsetX = (w - GAME_WIDTH * scale) / 2f;
+        offsetY = (h - GAME_HEIGHT * scale) / 2f;
+        touchTransform.setTranslate(-offsetX, -offsetY);
+        touchTransform.postScale(1f / scale, 1f / scale);
     }
 
     @Override
     public void onDraw(Canvas canvas) {
+        canvas.save();
+        canvas.translate(offsetX, offsetY);
+        canvas.scale(scale, scale);
         PacmanCanvas canvasEl = game.getCanvasEl();
-        canvasEl.setLeft((canvasWidth - CANVAS_WIDTH) / 2);
-        canvasEl.setTop((canvasHeight - CANVAS_HEIGHT) / 2);
+        canvasEl.setLeft(0);
+        canvasEl.setTop(0);
         canvasEl.draw(canvas);
+        canvas.restore();
     }
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
+        MotionEvent transformed = MotionEvent.obtain(event);
+        transformed.transform(touchTransform);
 
         switch (event.getAction() & MotionEvent.ACTION_MASK) {
         case MotionEvent.ACTION_DOWN:
-            game.handleTouchStart(event);
+            game.handleTouchStart(transformed);
             break;
         case MotionEvent.ACTION_UP:
-            game.handleTouchEnd(event);
+            game.handleTouchEnd(transformed);
             break;
         case MotionEvent.ACTION_MOVE:
-            game.handleTouchMove(event);
+            game.handleTouchMove(transformed);
             break;
         }
-
+        transformed.recycle();
         return true;
     }
 }


### PR DESCRIPTION
## Summary

- 固定サイズ（464×168）でのセンタリング表示から、画面サイズに合わせたスケール表示に変更
- アスペクト比を維持したまま画面いっぱいに拡大表示（レターボックス方式）
- 変更ファイルは `GameView.java` のみ、ゲームロジックの座標系は一切変更なし

## 実装の詳細

- `onSizeChanged` でスケール倍率とオフセットを1回だけ計算
- `onDraw` で `canvas.translate/scale` により拡大描画
- `onTouchEvent` でタッチ座標をゲーム空間に逆変換し、既存のヒット判定・スワイプ判定がそのまま動作
- タッチ変換用の `Matrix` をフィールドにキャッシュし、毎イベントでのオブジェクト生成を回避

## Test plan

- [x] `./gradlew assembleDebug` が BUILD SUCCESSFUL で完了することを確認
- [x] 実機でゲームが画面いっぱいに表示されることを確認
- [x] タッチ操作（スワイプ・タップ）が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)