### PR TITLE
Enable installation on tablets

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,8 +17,8 @@
     </application>
     <supports-screens android:smallScreens="false"
                       android:normalScreens="true"
-                      android:largeScreens="false"
-                      android:xlargeScreens="false"
-                      android:anyDensity="false" />
+                      android:largeScreens="true"
+                      android:xlargeScreens="true"
+                      android:anyDensity="true" />
     <uses-configuration android:reqTouchScreen="finger" />
 </manifest>


### PR DESCRIPTION
## Summary

- `largeScreens` / `xlargeScreens` が `false` になっていたためタブレットへのインストールが不可だったのを修正
- フルスクリーン対応（#10）により任意の画面サイズに対応済みのため、制限を解除
- `anyDensity` も `true` に変更（スケーリングで全密度に対応済みのため）

## Test plan

- [x] タブレットエミュレーターにインストールできることを確認
- [x] タブレットでゲームが正しく表示・動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)