### PR TITLE
Add margin around game field to reduce visual cramping

### DIFF
--- a/app/src/main/java/jp/or/iidukat/example/pacman/GameView.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GameView.java
@@ -14,6 +14,7 @@ class GameView extends View {
 
     private static final int GAME_WIDTH = 464;
     private static final int GAME_HEIGHT = 168;
+    private static final float MARGIN = 0.9f;
 
     private float scale = 1f;
     private float offsetX = 0f;
@@ -48,7 +49,7 @@ class GameView extends View {
 
     @Override
     protected void onSizeChanged(int w, int h, int oldw, int oldh) {
-        scale = Math.min((float) w / GAME_WIDTH, (float) h / GAME_HEIGHT);
+        scale = Math.min((float) w / GAME_WIDTH, (float) h / GAME_HEIGHT) * MARGIN;
         offsetX = (w - GAME_WIDTH * scale) / 2f;
         offsetY = (h - GAME_HEIGHT * scale) / 2f;
         touchTransform.setTranslate(-offsetX, -offsetY);


### PR DESCRIPTION
## Summary

- ゲームフィールドが画面いっぱいすぎて圧迫感があったため、四辺に均等な余白を追加
- `MARGIN = 0.9f` により画面の90%サイズで描画（上下左右それぞれ約5%の余白）
- 調整が必要な場合は `GameView.java` の `MARGIN` 定数を変更するだけで対応可能

## Test plan

- [x] 実機 / エミュレーターでゲームフィールド周辺に適切な余白が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)