### PR TITLE
Add debug cutscene button (debug builds only)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,10 @@ android {
         targetSdk 33
     }
 
+    buildFeatures {
+        buildConfig true
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17

--- a/app/src/main/java/jp/or/iidukat/example/pacman/GooglePacman.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GooglePacman.java
@@ -8,8 +8,11 @@ import android.view.View.OnClickListener;
 
 public class GooglePacman extends Activity implements OnClickListener {
 
+    private static final int CUTSCENE_COUNT = 3;
+
     private PacmanGame game;
     private GameView gameView;
+    private int nextCutsceneId = 1;
     
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -36,13 +39,20 @@ public class GooglePacman extends Activity implements OnClickListener {
     
     private void initMainView() {
         setContentView(R.layout.main);
-        
+
         View newGameButton = findViewById(R.id.new_game_button);
         newGameButton.setOnClickListener(this);
         View killScreenButton = findViewById(R.id.killscreen_button);
         killScreenButton.setOnClickListener(this);
+        View cutsceneButton = findViewById(R.id.cutscene_button);
+        cutsceneButton.setOnClickListener(this);
         View exitButton = findViewById(R.id.exit_button);
         exitButton.setOnClickListener(this);
+
+        if (!BuildConfig.DEBUG) {
+            killScreenButton.setVisibility(View.GONE);
+            cutsceneButton.setVisibility(View.GONE);
+        }
     }
     
     private void initGameView(PacmanGame game) {
@@ -71,6 +81,10 @@ public class GooglePacman extends Activity implements OnClickListener {
         } else if (id == R.id.killscreen_button) {
             transitionToGameView();
             game.showKillScreen();
+        } else if (id == R.id.cutscene_button) {
+            transitionToGameView();
+            game.showCutscene(nextCutsceneId);
+            nextCutsceneId = nextCutsceneId % CUTSCENE_COUNT + 1;
         } else if (id == R.id.exit_button) {
             finish();
         }

--- a/app/src/main/java/jp/or/iidukat/example/pacman/GooglePacman.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GooglePacman.java
@@ -13,6 +13,7 @@ public class GooglePacman extends Activity implements OnClickListener {
     private PacmanGame game;
     private GameView gameView;
     private int nextCutsceneId = 1;
+    private boolean inGameView = false;
     
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -64,12 +65,33 @@ public class GooglePacman extends Activity implements OnClickListener {
     private PacmanGame initGame() {
         game = new PacmanGame(this);
         game.init();
+        if (BuildConfig.DEBUG) {
+            game.setOnDebugCutsceneFinished(this::returnToMenu);
+        }
         return game;
     }
-    
+
     private void transitionToGameView() {
+        inGameView = true;
         setContentView(gameView);
         gameView.setFocusable(true);
+    }
+
+    private void returnToMenu() {
+        inGameView = false;
+        game.pause();
+        initGame();
+        initGameView(game);
+        initMainView();
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (inGameView) {
+            returnToMenu();
+        } else {
+            super.onBackPressed();
+        }
     }
 
     @Override

--- a/app/src/main/java/jp/or/iidukat/example/pacman/GooglePacman.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GooglePacman.java
@@ -81,6 +81,7 @@ public class GooglePacman extends Activity implements OnClickListener {
         inGameView = false;
         game.pause();
         initGame();
+        game.resume();
         initGameView(game);
         initMainView();
     }

--- a/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
@@ -813,6 +813,7 @@ public class PacmanGame {
     private int cutsceneId;
     private int cutsceneSequenceId;
     private double cutsceneTime;
+    private int debugCutsceneId;
 
     private double tickInterval;
     private double lastTimeDelta;
@@ -983,7 +984,11 @@ public class PacmanGame {
         dotEatingChannel = 0;
         dotEatingSoundPart = 1;
 
-        if (newGame) {
+        if (newGame && debugCutsceneId != 0) {
+            cutsceneId = debugCutsceneId;
+            debugCutsceneId = 0;
+            changeGameplayMode(GameplayMode.CUTSCENE);
+        } else if (newGame) {
             changeGameplayMode(GameplayMode.NEWGAME_STARTING);
         } else {
             changeGameplayMode(GameplayMode.GAME_RESTARTING);
@@ -1851,6 +1856,12 @@ public class PacmanGame {
 
     void showKillScreen() {
         setKillScreenLevel(1);
+        start();
+    }
+
+    void showCutscene(int id) {
+        debugCutsceneId = id;
+        setDefaultKillScreenLevel();
         start();
     }
 

--- a/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
@@ -814,6 +814,8 @@ public class PacmanGame {
     private int cutsceneSequenceId;
     private double cutsceneTime;
     private int debugCutsceneId;
+    private boolean debugCutsceneMode;
+    private Runnable onDebugCutsceneFinished;
 
     private double tickInterval;
     private double lastTimeDelta;
@@ -1426,7 +1428,14 @@ public class PacmanGame {
         getPlayfieldEl().setVisibility(true);
         canvasEl.removeCutsceneField();
         canvasEl.showChrome(true);
-        newLevel(false);
+        if (debugCutsceneMode) {
+            debugCutsceneMode = false;
+            if (onDebugCutsceneFinished != null) {
+                onDebugCutsceneFinished.run();
+            }
+        } else {
+            newLevel(false);
+        }
     }
 
     private void cutsceneNextSequence() {
@@ -1861,8 +1870,13 @@ public class PacmanGame {
 
     void showCutscene(int id) {
         debugCutsceneId = id;
+        debugCutsceneMode = true;
         setDefaultKillScreenLevel();
         start();
+    }
+
+    void setOnDebugCutsceneFinished(Runnable callback) {
+        this.onDebugCutsceneFinished = callback;
     }
 
     private void prepareSound() {

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -24,6 +24,11 @@
             android:layout_height="wrap_content"
             android:text="@string/killscreen_label" />
         <Button
+            android:id="@+id/cutscene_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/cutscene_label" />
+        <Button
             android:id="@+id/exit_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="new_game_label">Insert Coin</string>
     <string name="killscreen_label">Kill Screen</string>
     <string name="exit_label">Exit</string>
+    <string name="cutscene_label">Cutscene</string>
 </resources>


### PR DESCRIPTION
## Summary

- メインメニューに「Cutscene」ボタンを追加（デバッグビルドのみ表示）
- タップするたびにカットシーン 1→2→3→1 とサイクルして再生
- Kill Screen ボタンもリリースビルドでは非表示に変更
- AGP 8.0 以降でデフォルト無効になった `BuildConfig` 生成を `buildFeatures { buildConfig true }` で明示的に有効化

## 実装の詳細

- `PacmanGame#showCutscene(int id)`: `debugCutsceneId` を設定して `start()` を呼び出し、`restartGameplay` 内でカットシーンモードへ分岐
- `GooglePacman`: `BuildConfig.DEBUG` でデバッグボタンの表示/非表示を切り替え

## Test plan

- [x] デバッグビルドでメインメニューに Cutscene / Kill Screen ボタンが表示されることを確認
- [x] Cutscene ボタンをタップするたびに 1→2→3→1 の順でカットシーンが再生されることを確認
- [x] リリースビルド（`assembleRelease`）ではボタンが非表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)