### PR TITLE
Architecture Phase 4: extract TickClock, consolidate constants, fix tickInterval bug

### DIFF
--- a/app/src/main/java/jp/or/iidukat/example/pacman/GameConstants.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GameConstants.java
@@ -1,0 +1,29 @@
+package jp.or.iidukat.example.pacman;
+
+class GameConstants {
+    static final int DEFAULT_FPS = 90;
+    static final int[] FPS_OPTIONS = { 90, 45, 30 };
+
+    static final double[] EVENT_TIME_TABLE = {
+        0.16f,
+        0.23f,
+        1,
+        1,
+        2.23f,
+        0.3f,
+        1.9f,
+        2.23f,
+        1.9f,
+        5,
+        1.9f,
+        1.18f,
+        0.3f,
+        0.5f,
+        1.9f,
+        9,
+        10,
+        0.26f
+    };
+
+    static final double FRIGHT_BLINK_SECS = EVENT_TIME_TABLE[1];
+}

--- a/app/src/main/java/jp/or/iidukat/example/pacman/GameTimerManager.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GameTimerManager.java
@@ -1,0 +1,4 @@
+package jp.or.iidukat.example.pacman;
+
+// Renamed to TickClock.
+class GameTimerManager {}

--- a/app/src/main/java/jp/or/iidukat/example/pacman/GameTimerManager.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GameTimerManager.java
@@ -1,4 +1,0 @@
-package jp.or.iidukat.example.pacman;
-
-// Renamed to TickClock.
-class GameTimerManager {}

--- a/app/src/main/java/jp/or/iidukat/example/pacman/LevelConfig.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/LevelConfig.java
@@ -2,7 +2,8 @@ package jp.or.iidukat.example.pacman;
 
 public class LevelConfig {
 
-    static final int DEFAULT_FPS = 90;
+    private static final int FRIGHT_BLINK_DURATION =
+            (int) Math.round(GameConstants.FRIGHT_BLINK_SECS * GameConstants.DEFAULT_FPS);
 
     private final double ghostSpeed;
     private final double ghostTunnelSpeed;
@@ -16,7 +17,7 @@ public class LevelConfig {
     private final int elroyDotsLeftPart2;
     private final double elroySpeedPart2;
     private final int frightTime;
-    private int frightTotalTime;
+    private final int frightTotalTime;
     private final int frightBlinkCount;
     private final int fruit;
     private final int fruitScore;
@@ -88,7 +89,8 @@ public class LevelConfig {
         this.penForceTime = builder.penForceTime;
         this.penLeavingLimits = builder.penLeavingLimits;
         this.cutsceneId = builder.cutsceneId;
-        this.frightTime = builder.frightTime * DEFAULT_FPS;
+        this.frightTime = builder.frightTime * GameConstants.DEFAULT_FPS;
+        this.frightTotalTime = this.frightTime + FRIGHT_BLINK_DURATION * (this.frightBlinkCount * 2 - 1);
     }
 
     public double getGhostSpeed() { return ghostSpeed; }
@@ -104,10 +106,6 @@ public class LevelConfig {
     public double getElroySpeedPart2() { return elroySpeedPart2; }
     public int getFrightTime() { return frightTime; }
     public int getFrightTotalTime() { return frightTotalTime; }
-
-    void initFrightTotalTime(int blinkDuration) {
-        this.frightTotalTime = this.frightTime + blinkDuration * (this.frightBlinkCount * 2 - 1);
-    }
 
     public int getFrightBlinkCount() { return frightBlinkCount; }
     public int getFruit() { return fruit; }

--- a/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
@@ -43,33 +43,6 @@ public class PacmanGame {
     // This is the thresholds of each ghost.
     private static final int[] PEN_LEAVING_FOOD_LIMITS = { 0, 7, 17, 32 };
 
-    private static final double[] EVENT_TIME_TABLE = {
-        0.16f,
-        0.23f,
-        1,
-        1,
-        2.23f,
-        0.3f,
-        1.9f,
-        2.23f,
-        1.9f,
-        5,
-        1.9f,
-        1.18f,
-        0.3f,
-        0.5f,
-        1.9f,
-        9,
-        10,
-        0.26f
-    };
-
-    private static final int[] FPS_OPTIONS = { 90, 45, 30, };
-    private static final int DEFAULT_FPS = FPS_OPTIONS[0];
-
-
-    
-
     // Cutscene Animation
     private static class Cutscene {
         private final Class<?>[] actors;
@@ -179,15 +152,7 @@ public class PacmanGame {
     private int debugCutsceneId;
     private boolean debugCutsceneMode;
     private Runnable onDebugCutsceneFinished;
-    private double tickInterval;
-    private double lastTimeDelta;
-    private long lastTime;
-    private long pausedTime;
-    private int fpsChoice;
-    private int fps;
-    private boolean canDecreaseFps;
-    private int lastTimeSlownessCount;
-    private int tickMultiplier;
+    private TickClock tickClock;
 
     PacmanGame(Context context) {
         this.context = context;
@@ -263,7 +228,7 @@ public class PacmanGame {
         gameplayModeTime = 0;
         fruitTime = 0;
         ghostModeSwitchPos = 0;
-        ghostModeTime = levelConfig.getGhostModeSwitchTimes()[0] * DEFAULT_FPS;
+        ghostModeTime = levelConfig.getGhostModeSwitchTimes()[0] * GameConstants.DEFAULT_FPS;
         ghostExitingPenNow = false;
         ghostEyesCount = 0;
         tilesChanged = false;
@@ -309,7 +274,6 @@ public class PacmanGame {
             level >= LevelConfig.LEVEL_CONFIGS.length
                 ? LevelConfig.LEVEL_CONFIGS[LevelConfig.LEVEL_CONFIGS.length - 1]
                 : LevelConfig.LEVEL_CONFIGS[level];
-        levelConfig.initFrightTotalTime((int) timing[1]);
         alternatePenLeavingScheme = false;
         lostLifeOnThisLevel = false;
         updateChrome();
@@ -441,7 +405,7 @@ public class PacmanGame {
     }
 
     private void resetForcePenLeaveTime() {
-        forcePenLeaveTime = levelConfig.getPenForceTime() * DEFAULT_FPS;
+        forcePenLeaveTime = levelConfig.getPenForceTime() * GameConstants.DEFAULT_FPS;
     }
 
     public void dotEaten(int[] dotPos) {
@@ -575,7 +539,7 @@ public class PacmanGame {
             double distance = 0;
             double lastPos = 0;
             List<Boolean> movabilityTimeTable = new ArrayList<Boolean>();
-            for (int i = 0; i < DEFAULT_FPS; i++) {
+            for (int i = 0; i < GameConstants.DEFAULT_FPS; i++) {
                 distance += speed;
                 double pos = Math.floor(distance);
                 if (pos > lastPos) {
@@ -733,7 +697,7 @@ public class PacmanGame {
         if (cutscene.sequenceTimes.length == cutsceneSequenceId) {
             stopCutscene();
         } else {
-            cutsceneTime = cutscene.sequenceTimes[cutsceneSequenceId] * DEFAULT_FPS;
+            cutsceneTime = cutscene.sequenceTimes[cutsceneSequenceId] * GameConstants.DEFAULT_FPS;
             CutsceneActor[] cutsceneActors = getCutsceneActors();
             for (int i = 0; i < cutsceneActors.length; i++) {
                 CutsceneActor actor = cutsceneActors[i];
@@ -881,7 +845,7 @@ public class PacmanGame {
                 ghostModeTime = 0;
                 ghostModeSwitchPos++;
                 if (ghostModeSwitchPos < levelConfig.getGhostModeSwitchTimes().length) {
-                    ghostModeTime = levelConfig.getGhostModeSwitchTimes()[ghostModeSwitchPos] * DEFAULT_FPS;
+                    ghostModeTime = levelConfig.getGhostModeSwitchTimes()[ghostModeSwitchPos] * GameConstants.DEFAULT_FPS;
                     switch (mainGhostMode) {
                     case SCATTER:
                         switchMainGhostMode(GhostMode.CHASE, false);
@@ -924,42 +888,24 @@ public class PacmanGame {
     void tick() {
         long now = new Date().getTime();
         if (paused) {
-            pausedTime = now;
+            tickClock.onPaused(now);
             return;
         }
 
-        lastTimeDelta += now - lastTime - tickInterval; // total processing delay
-        if (lastTimeDelta > 100) {
-            lastTimeDelta = 100;
-        }
-        if (canDecreaseFps && lastTimeDelta > 50) {
-            // If the fps can be reduced, count the number of process which latency is over 50 ms.
-            lastTimeSlownessCount++;
-            if (lastTimeSlownessCount == 20) {
-                decreaseFps(); // reduce the fps when the number of process, which latency is over 50 ms, becomes 20.
-            }
-        }
-        int latencyMultiplyer = 0;
-        if (lastTimeDelta > tickInterval) {
-            // If the total processing delay is greater than tick​​Interval,
-            // the total processing delay is cut down to less than tickInterval.
-            latencyMultiplyer = (int) Math.floor(lastTimeDelta / tickInterval);
-            lastTimeDelta -= tickInterval * latencyMultiplyer;
-        }
-        lastTime = now;
+        int latencyMultiplyer = tickClock.advance(now);
         if (gameplayMode == GameplayMode.CUTSCENE) { // Cutscene
-            for (int i = 0; i < tickMultiplier + latencyMultiplyer; i++) {
+            for (int i = 0; i < tickClock.tickMultiplier + latencyMultiplyer; i++) {
                 // run multiple time depending on the tickMultiplier and latency
                 advanceCutscene();
-                intervalTime = (intervalTime + 1) % DEFAULT_FPS;
+                intervalTime = (intervalTime + 1) % GameConstants.DEFAULT_FPS;
                 globalTime++;
             }
             checkCutscene();
             blinkScoreLabels();
         } else {
             updateSoundIcon();
-            
-            for (int i = 0; i < tickMultiplier + latencyMultiplyer; i++) {
+
+            for (int i = 0; i < tickClock.tickMultiplier + latencyMultiplyer; i++) {
                 // run multiple time depending on the tickMultiplier and latency
                 inputHandler.processDpadInput();
                 moveActors();
@@ -971,7 +917,7 @@ public class PacmanGame {
                 }
 
                 globalTime++;
-                intervalTime = (intervalTime + 1) % DEFAULT_FPS;
+                intervalTime = (intervalTime + 1) % GameConstants.DEFAULT_FPS;
                 blinkEnergizers();
                 blinkScoreLabels();
                 handleTimers();
@@ -1045,32 +991,17 @@ public class PacmanGame {
         soundManager.playAmbient(ambient);
     }
 
-    private void initializeTickTimer() {
-        fps = FPS_OPTIONS[fpsChoice];
-        tickInterval = 1000 / fps;
-        tickMultiplier = DEFAULT_FPS / fps;
-        timing = new double[EVENT_TIME_TABLE.length];
-        for (int i = 0; i < EVENT_TIME_TABLE.length; i++) {
-            double sec = !soundManager.isPacManSound() && (i == 7 || i == 8) ? 1 : EVENT_TIME_TABLE[i];
-            timing[i] = Math.round(sec * DEFAULT_FPS);
+    private void initTiming() {
+        timing = new double[GameConstants.EVENT_TIME_TABLE.length];
+        for (int i = 0; i < GameConstants.EVENT_TIME_TABLE.length; i++) {
+            double sec = !soundManager.isPacManSound() && (i == 7 || i == 8)
+                    ? 1 : GameConstants.EVENT_TIME_TABLE[i];
+            timing[i] = Math.round(sec * GameConstants.DEFAULT_FPS);
         }
-        lastTime = new Date().getTime();
-        lastTimeDelta = 0;
-        lastTimeSlownessCount = 0;
     }
 
     private void setTimeout() {
-        view.redrawHandler.sleep(Math.round(tickInterval));
-    }
-
-    private void decreaseFps() {
-        if (fpsChoice < FPS_OPTIONS.length - 1) {
-            fpsChoice++;
-            initializeTickTimer();
-            if (fpsChoice == FPS_OPTIONS.length - 1) {
-                canDecreaseFps = false;
-            }
-        }
+        view.redrawHandler.sleep(tickClock.getTickIntervalMs());
     }
 
     private void createCanvasElement() {
@@ -1122,15 +1053,15 @@ public class PacmanGame {
         speedIntervals = new HashMap<Double, Boolean[]>();
         soundManager = new SoundManager(context);
         inputHandler = new InputHandler(this);
-        fpsChoice = 0;
-        canDecreaseFps = true;
-        initializeTickTimer();
+        tickClock = new TickClock();
+        tickClock.init();
+        initTiming();
     }
 
     void resume() {
         soundManager.reinit();
         if (started && paused) {
-            lastTime += new Date().getTime() - pausedTime;
+            tickClock.onResumed();
             paused = false;
             soundManager.resumeAmbient();
             tick();

--- a/app/src/main/java/jp/or/iidukat/example/pacman/TickClock.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/TickClock.java
@@ -1,0 +1,74 @@
+package jp.or.iidukat.example.pacman;
+
+import java.util.Date;
+
+class TickClock {
+
+    private double tickInterval;
+    private double lastTimeDelta;
+    private long lastTime;
+    private long pausedTime;
+    private int fpsChoice;
+    private boolean canDecreaseFps;
+    private int lastTimeSlownessCount;
+    int tickMultiplier;
+
+    void init() {
+        fpsChoice = 0;
+        canDecreaseFps = true;
+        applyFps();
+    }
+
+    private void applyFps() {
+        int fps = GameConstants.FPS_OPTIONS[fpsChoice];
+        tickInterval = 1000.0 / fps;
+        tickMultiplier = GameConstants.DEFAULT_FPS / fps;
+        lastTime = new Date().getTime();
+        lastTimeDelta = 0;
+        lastTimeSlownessCount = 0;
+    }
+
+    void onPaused(long now) {
+        pausedTime = now;
+    }
+
+    void onResumed() {
+        lastTime += new Date().getTime() - pausedTime;
+    }
+
+    // Returns the number of extra game steps to run to compensate for accumulated latency.
+    int advance(long now) {
+        lastTimeDelta += now - lastTime - tickInterval;
+        if (lastTimeDelta > 100) {
+            lastTimeDelta = 100;
+        }
+        if (canDecreaseFps && lastTimeDelta > 50) {
+            // Count consecutive slow ticks; reduce fps after 20 in a row.
+            lastTimeSlownessCount++;
+            if (lastTimeSlownessCount == 20) {
+                decreaseFps();
+            }
+        }
+        int latencyMultiplier = 0;
+        if (lastTimeDelta > tickInterval) {
+            latencyMultiplier = (int) Math.floor(lastTimeDelta / tickInterval);
+            lastTimeDelta -= tickInterval * latencyMultiplier;
+        }
+        lastTime = now;
+        return latencyMultiplier;
+    }
+
+    long getTickIntervalMs() {
+        return Math.round(tickInterval);
+    }
+
+    private void decreaseFps() {
+        if (fpsChoice < GameConstants.FPS_OPTIONS.length - 1) {
+            fpsChoice++;
+            applyFps();
+            if (fpsChoice == GameConstants.FPS_OPTIONS.length - 1) {
+                canDecreaseFps = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **`GameConstants`** 新規作成: `DEFAULT_FPS`・`FPS_OPTIONS`・`EVENT_TIME_TABLE`・`FRIGHT_BLINK_SECS` を一元管理
- **`TickClock`** 新規作成: tick クロック管理（FPS 制御・レイテンシ補正・次 tick スケジューリング）を `PacmanGame` から抽出。`globalTime`・`intervalTime` 等のゲームイベントタイマーは `PacmanGame` に残置
- **`LevelConfig`**: `frightTotalTime` をコンストラクタで確定させ、`initFrightTotalTime()` を削除（`LevelConfig` が完全 immutable に）
- **`PacmanGame`**: `initializeTickTimer()` を `tickClock.init()` + `initTiming()` に分離。`EVENT_TIME_TABLE`・`FPS_OPTIONS`・`DEFAULT_FPS` 定数を削除
- **バグ修正**: `tickInterval = 1000 / fps`（整数除算）→ `1000.0 / fps`（浮動小数点除算）

### スコープ外（次 PR 予定）
- `timing[]` のオブジェクト化（インデックス → 名前付きフィールド）

## Test plan
- [x] 通常ゲームプレイで動作が正常（スワイプ・Dpad・ゴースト AI）
- [x] ポーズ → 再開が正常に動作する
- [x] FPS 低下時に自動 FPS 削減が機能する（重い端末で確認）
- [x] カットシーン再生が正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)