### PR TITLE
Replace double[] timing with named-field Timing object (Architecture Phase 5)

### DIFF
--- a/app/src/main/java/jp/or/iidukat/example/pacman/GameConstants.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GameConstants.java
@@ -4,26 +4,4 @@ class GameConstants {
     static final int DEFAULT_FPS = 90;
     static final int[] FPS_OPTIONS = { 90, 45, 30 };
 
-    static final double[] EVENT_TIME_TABLE = {
-        0.16f,
-        0.23f,
-        1,
-        1,
-        2.23f,
-        0.3f,
-        1.9f,
-        2.23f,
-        1.9f,
-        5,
-        1.9f,
-        1.18f,
-        0.3f,
-        0.5f,
-        1.9f,
-        9,
-        10,
-        0.26f
-    };
-
-    static final double FRIGHT_BLINK_SECS = EVENT_TIME_TABLE[1];
 }

--- a/app/src/main/java/jp/or/iidukat/example/pacman/LevelConfig.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/LevelConfig.java
@@ -3,7 +3,7 @@ package jp.or.iidukat.example.pacman;
 public class LevelConfig {
 
     private static final int FRIGHT_BLINK_DURATION =
-            (int) Math.round(GameConstants.FRIGHT_BLINK_SECS * GameConstants.DEFAULT_FPS);
+            (int) Math.round(Timing.FRIGHT_BLINK_SECS * GameConstants.DEFAULT_FPS);
 
     private final double ghostSpeed;
     private final double ghostTunnelSpeed;

--- a/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
@@ -128,7 +128,7 @@ public class PacmanGame {
     private int ghostEyesCount = 0;
     private boolean tilesChanged = false;
     private GameplayMode gameplayMode;
-    private double[] timing;
+    private Timing timing;
     private boolean alternatePenLeavingScheme;
     private int alternateDotCount;
     private boolean lostLifeOnThisLevel;
@@ -451,8 +451,8 @@ public class PacmanGame {
         fruitShown = true;
         getFruitEl().show();
         fruitTime =
-            (int) timing[15]
-                + (int) ((timing[16] - timing[15]) * rand());
+            (int) timing.fruitShowMin
+                + (int) ((timing.fruitShowMax - timing.fruitShowMin) * rand());
     }
 
     public void eatFruit() {
@@ -460,7 +460,7 @@ public class PacmanGame {
             soundManager.playTrack("fruit", 0);
             fruitShown = false;
             getFruitEl().eaten();
-            fruitTime = (int) timing[14];
+            fruitTime = (int) timing.fruitScore;
             addToScore(levelConfig.getFruitScore());
         }
     }
@@ -575,56 +575,56 @@ public class PacmanGame {
             break;
         case PLAYER_DYING:
             soundManager.stopAll();
-            gameplayModeTime = timing[3];
+            gameplayModeTime = timing.playerDying;
             break;
         case PLAYER_DIED:
             soundManager.playTrack("death", 0);
-            gameplayModeTime = timing[4];
+            gameplayModeTime = timing.playerDied;
             break;
         case GAME_RESTARTING:
             canvasEl.setVisibility(false);
-            gameplayModeTime = timing[5];
+            gameplayModeTime = timing.gameRestarting;
             break;
         case GAME_RESTARTED:
             soundManager.stopAll();
             canvasEl.setVisibility(true);
             getDoorEl().setVisibility(true);
             createReadyElement();
-            gameplayModeTime = timing[6];
+            gameplayModeTime = timing.gameRestarted;
             break;
         case NEWGAME_STARTING:
             getDoorEl().setVisibility(true);
             createReadyElement();
-            gameplayModeTime = timing[7];
+            gameplayModeTime = timing.newgameStarting;
             soundManager.stopAll();
             soundManager.playTrack("start_music", 0, true);
             break;
         case NEWGAME_STARTED:
             lives--;
             updateChromeLives();
-            gameplayModeTime = timing[8];
+            gameplayModeTime = timing.newgameStarted;
             break;
         case GAMEOVER:
         case KILL_SCREEN:
             removeReadyElement();
             soundManager.stopAll();
             createGameOverElement();
-            gameplayModeTime = timing[9];
+            gameplayModeTime = timing.gameover;
             break;
         case LEVEL_BEING_COMPLETED:
             soundManager.stopAll();
-            gameplayModeTime = timing[10];
+            gameplayModeTime = timing.levelBeingCompleted;
             break;
         case LEVEL_COMPLETED:
             getDoorEl().setVisibility(false);
-            gameplayModeTime = timing[11];
+            gameplayModeTime = timing.levelCompleted;
             break;
         case TRANSITION_INTO_NEXT_SCENE:
             canvasEl.setVisibility(false);
-            gameplayModeTime = timing[12];
+            gameplayModeTime = timing.transition;
             break;
         case GHOST_DIED:
-            gameplayModeTime = timing[2];
+            gameplayModeTime = timing.ghostDied;
             break;
         case CUTSCENE:
             startCutscene();
@@ -730,11 +730,11 @@ public class PacmanGame {
     }
 
     private void blinkEnergizers() {
-        getPlayfieldEl().blinkEnergizers(gameplayMode, globalTime, timing[0]);
+        getPlayfieldEl().blinkEnergizers(gameplayMode, globalTime, timing.energizerBlink);
     }
 
     private void blinkScoreLabels() {
-        getScoreLabelEl().update(gameplayMode, globalTime, timing[17]);
+        getScoreLabelEl().update(gameplayMode, globalTime, timing.scoreLabelBlink);
     }
 
     private void finishFrightMode() {
@@ -754,7 +754,7 @@ public class PacmanGame {
                 }
                 break;
             case LEVEL_COMPLETED:
-                getPlayfieldEl().blink(gameplayModeTime, timing[11]);
+                getPlayfieldEl().blink(gameplayModeTime, timing.levelCompleted);
                 break;
             }
 
@@ -992,12 +992,7 @@ public class PacmanGame {
     }
 
     private void initTiming() {
-        timing = new double[GameConstants.EVENT_TIME_TABLE.length];
-        for (int i = 0; i < GameConstants.EVENT_TIME_TABLE.length; i++) {
-            double sec = !soundManager.isPacManSound() && (i == 7 || i == 8)
-                    ? 1 : GameConstants.EVENT_TIME_TABLE[i];
-            timing[i] = Math.round(sec * GameConstants.DEFAULT_FPS);
-        }
+        timing = new Timing(!soundManager.isPacManSound());
     }
 
     private void setTimeout() {
@@ -1222,8 +1217,16 @@ public class PacmanGame {
         return gameplayModeTime;
     }
 
-    public double[] getTiming() {
+    Timing getTiming() {
         return timing;
+    }
+
+    public double getFrightBlinkTiming() {
+        return timing.frightBlink;
+    }
+
+    public double getPlayerDiedTiming() {
+        return timing.playerDied;
     }
 
     public GameplayMode getGameplayMode() {

--- a/app/src/main/java/jp/or/iidukat/example/pacman/Timing.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/Timing.java
@@ -1,0 +1,45 @@
+package jp.or.iidukat.example.pacman;
+
+class Timing {
+
+    static final double FRIGHT_BLINK_SECS = 0.23;
+
+    final double energizerBlink;
+    final double frightBlink;
+    final double ghostDied;
+    final double playerDying;
+    final double playerDied;
+    final double gameRestarting;
+    final double gameRestarted;
+    final double newgameStarting;
+    final double newgameStarted;
+    final double gameover;
+    final double levelBeingCompleted;
+    final double levelCompleted;
+    final double transition;
+    final double fruitScore;
+    final double fruitShowMin;
+    final double fruitShowMax;
+    final double scoreLabelBlink;
+
+    Timing(boolean noSound) {
+        int fps = GameConstants.DEFAULT_FPS;
+        energizerBlink      = Math.round(0.16  * fps);
+        frightBlink         = Math.round(FRIGHT_BLINK_SECS * fps);
+        ghostDied           = Math.round(1.0   * fps);
+        playerDying         = Math.round(1.0   * fps);
+        playerDied          = Math.round(2.23  * fps);
+        gameRestarting      = Math.round(0.3   * fps);
+        gameRestarted       = Math.round(1.9   * fps);
+        newgameStarting     = Math.round((noSound ? 1.0 : 2.23) * fps);
+        newgameStarted      = Math.round((noSound ? 1.0 : 1.9)  * fps);
+        gameover            = Math.round(5.0   * fps);
+        levelBeingCompleted = Math.round(1.9   * fps);
+        levelCompleted      = Math.round(1.18  * fps);
+        transition          = Math.round(0.3   * fps);
+        fruitScore          = Math.round(1.9   * fps);
+        fruitShowMin        = Math.round(9.0   * fps);
+        fruitShowMax        = Math.round(10.0  * fps);
+        scoreLabelBlink     = Math.round(0.26  * fps);
+    }
+}

--- a/app/src/main/java/jp/or/iidukat/example/pacman/entity/CutsceneBlinky.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/entity/CutsceneBlinky.java
@@ -115,7 +115,7 @@ public class CutsceneBlinky extends CutsceneActor {
                     < game.getLevelConfig().getFrightTotalTime()
                         - game.getLevelConfig().getFrightTime()
                 && Math.floor(
-                        game.getFrightModeTime() / game.getTiming()[1])
+                        game.getFrightModeTime() / game.getFrightBlinkTiming())
                         % 2 == 0) {
                 x += 2;
             }

--- a/app/src/main/java/jp/or/iidukat/example/pacman/entity/Ghost.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/entity/Ghost.java
@@ -409,7 +409,7 @@ public abstract class Ghost extends PlayfieldActor {
             y = 8;
             // blinking before the end of the frighten mode
             if (game.getFrightModeTime() < game.getLevelConfig().getFrightTotalTime() - game.getLevelConfig().getFrightTime()
-                    && Math.floor(game.getFrightModeTime() / game.getTiming()[1]) % 2 == 0) {
+                    && Math.floor(game.getFrightModeTime() / game.getFrightBlinkTiming()) % 2 == 0) {
                 x += 2;
             }
     

--- a/app/src/main/java/jp/or/iidukat/example/pacman/entity/Pacman.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/entity/Pacman.java
@@ -233,7 +233,7 @@ public class Pacman extends PlayfieldActor {
             x = 2;
             y = 0;
         } else if (game.getGameplayMode() == GameplayMode.PLAYER_DIED) {
-            int t = 20 - (int) Math.floor(game.getGameplayModeTime() / game.getTiming()[4] * 21);
+            int t = 20 - (int) Math.floor(game.getGameplayModeTime() / game.getPlayerDiedTiming() * 21);
             x = t - 1;
             switch (x) {
             case -1:


### PR DESCRIPTION
## Summary

- **New `Timing.java`**: replaces `double[] timing` array with named fields (`energizerBlink`, `frightBlink`, `playerDied`, etc.) computed inline — `EVENT_TIME_TABLE` array eliminated entirely
- **`FRIGHT_BLINK_SECS`** moved from `GameConstants` to `Timing` as a package-private static constant; `LevelConfig` references `Timing.FRIGHT_BLINK_SECS`
- **Visibility design**: `Timing` class remains package-private; `getTiming()` demoted to package-private; `PacmanGame` exposes `getFrightBlinkTiming()` and `getPlayerDiedTiming()` as public getters for entity subpackage — avoids leaking the `Timing` type across package boundaries
- **Entity callers updated**: `getTiming()[1]` / `getTiming()[4]` replaced with typed getter calls in `Ghost`, `CutsceneBlinky`, and `Pacman`
- Sound-dependent values (`newgameStarting`, `newgameStarted`) handled via `boolean noSound` constructor parameter at app init time (same behavior as before)

## Test plan
- [x] Build passes (`assembleDebug`)
- [x] Fright mode blink animation works correctly
- [x] Player death animation plays to completion
- [x] Level complete / game over state transitions fire at correct times
- [x] Fruit display duration is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)