### PR TITLE
Architecture Phase 7: decompose PacmanGame responsibilities (A–D)

### DIFF
--- a/app/src/main/java/jp/or/iidukat/example/pacman/CutsceneController.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/CutsceneController.java
@@ -1,0 +1,151 @@
+package jp.or.iidukat.example.pacman;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import jp.or.iidukat.example.pacman.entity.CutsceneActor;
+import jp.or.iidukat.example.pacman.entity.CutsceneBlinky;
+import jp.or.iidukat.example.pacman.entity.CutscenePacman;
+import jp.or.iidukat.example.pacman.entity.CutsceneSteak;
+
+class CutsceneController {
+
+    private static class Cutscene {
+        private final Class<?>[] actors;
+        private final double[] sequenceTimes;
+
+        Cutscene(Class<?>[] actors, double[] sequenceTimes) {
+            this.actors = actors;
+            this.sequenceTimes = sequenceTimes;
+        }
+    }
+
+    private static final Map<Integer, Cutscene> CUTSCENES;
+    static {
+        Map<Integer, Cutscene> css = new HashMap<Integer, Cutscene>();
+        css.put(
+            Integer.valueOf(1),
+            new Cutscene(
+                new Class<?>[] { CutscenePacman.class, CutsceneBlinky.class },
+                new double[] { 5.5f, 0.1f, 9 }));
+        css.put(
+            Integer.valueOf(2),
+            new Cutscene(
+                new Class<?>[] {
+                    CutscenePacman.class,
+                    CutsceneBlinky.class,
+                    CutsceneSteak.class
+                },
+                new double[] { 2.7f, 1, 1.3f, 1, 2.5f }));
+        css.put(
+            Integer.valueOf(3),
+            new Cutscene(
+                new Class<?>[] { CutscenePacman.class, CutsceneBlinky.class },
+                new double[] { 5.3f, 5.3f }));
+        CUTSCENES = Collections.unmodifiableMap(css);
+    }
+
+    private final PacmanGame game;
+
+    private Cutscene cutscene;
+    int cutsceneId;
+    private int cutsceneSequenceId;
+    private double cutsceneTime;
+    private int debugCutsceneId;
+    private boolean debugCutsceneMode;
+    private Runnable onDebugCutsceneFinished;
+
+    CutsceneController(PacmanGame game) {
+        this.game = game;
+    }
+
+    int getCutsceneId() { return cutsceneId; }
+
+    void setCutsceneId(int id) { cutsceneId = id; }
+
+    int getCutsceneSequenceId() { return cutsceneSequenceId; }
+
+    double getCutsceneTime() { return cutsceneTime; }
+
+    boolean hasDebugCutscene() { return debugCutsceneId != 0; }
+
+    void consumeDebugCutscene() {
+        cutsceneId = debugCutsceneId;
+        debugCutsceneId = 0;
+    }
+
+    void setDebugCutsceneId(int id) {
+        debugCutsceneId = id;
+        debugCutsceneMode = true;
+    }
+
+    void setOnFinished(Runnable callback) {
+        onDebugCutsceneFinished = callback;
+    }
+
+    void start() {
+        game.getPlayfieldEl().setVisibility(false);
+
+        game.getCanvasEl().setVisibility(true);
+        game.getCanvasEl().showChrome(false);
+        game.getCanvasEl().createCutsceneField();
+
+        cutscene = CUTSCENES.get(Integer.valueOf(cutsceneId));
+        cutsceneSequenceId = -1;
+        game.getGameTimerManager().setFrightModeTime(game.getLevelConfig().getFrightTotalTime());
+        createActors();
+
+        nextSequence();
+        game.getSoundManager().stopAll();
+        game.getSoundManager().playCutsceneAmbient();
+    }
+
+    void stop() {
+        game.getSoundManager().stopCutsceneAmbient();
+        game.getPlayfieldEl().setVisibility(true);
+        game.getCanvasEl().removeCutsceneField();
+        game.getCanvasEl().showChrome(true);
+        if (debugCutsceneMode) {
+            debugCutsceneMode = false;
+            if (onDebugCutsceneFinished != null) {
+                onDebugCutsceneFinished.run();
+            }
+        } else {
+            game.newLevel(false);
+        }
+    }
+
+    void advance() {
+        CutsceneActor[] cutsceneActors = game.getCanvasEl().getCutsceneField().getActors();
+        for (CutsceneActor actor : cutsceneActors) {
+            actor.move();
+        }
+        cutsceneTime--;
+    }
+
+    void check() {
+        if (cutsceneTime <= 0) {
+            nextSequence();
+        }
+    }
+
+    private void nextSequence() {
+        cutsceneSequenceId++;
+        if (cutscene.sequenceTimes.length == cutsceneSequenceId) {
+            stop();
+        } else {
+            cutsceneTime = cutscene.sequenceTimes[cutsceneSequenceId] * GameConstants.DEFAULT_FPS;
+            CutsceneActor[] cutsceneActors = game.getCanvasEl().getCutsceneField().getActors();
+            for (int i = 0; i < cutsceneActors.length; i++) {
+                CutsceneActor actor = cutsceneActors[i];
+                actor.setupSequence();
+                actor.updateAppearance();
+            }
+        }
+    }
+
+    private void createActors() {
+        game.getCanvasEl().getCutsceneField().createActors(game, cutsceneId, cutscene.actors);
+    }
+}

--- a/app/src/main/java/jp/or/iidukat/example/pacman/GameTimerManager.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GameTimerManager.java
@@ -118,66 +118,7 @@ class GameTimerManager {
 
             if (game.getGameplayModeTime() <= 0) {
                 game.resetGameplayModeTime();
-                Ghost[] ghosts = game.getGhosts();
-                switch (game.getGameplayMode()) {
-                case GHOST_DIED:
-                    game.changeGameplayMode(GameplayMode.ORDINARY_PLAYING);
-                    game.incrementGhostEyesCount();
-                    game.playAmbientSound();
-                    game.getGhostBeingEaten().resetDisplayOrder();
-                    game.getGhostBeingEaten().switchGhostMode(GhostMode.EATEN);
-                    // If there is no ghost frightened, finish fright mode.
-                    boolean frightenedGhostExists = false;
-                    for (Ghost ghost : ghosts) {
-                        if (ghost.getMode() == GhostMode.FRIGHTENED
-                            || (ghost.getMode() == GhostMode.IN_PEN
-                                    || ghost.getMode() == GhostMode.RE_LEAVING_FROM_PEN)
-                                && !ghost.isEatenInThisFrightMode()) {
-                            frightenedGhostExists = true;
-                            break;
-                        }
-                    }
-                    if (!frightenedGhostExists) {
-                        game.finishFrightMode();
-                    }
-                    break;
-                case PLAYER_DYING:
-                    game.changeGameplayMode(GameplayMode.PLAYER_DIED);
-                    break;
-                case PLAYER_DIED:
-                    game.newLife();
-                    break;
-                case NEWGAME_STARTING:
-                    game.changeGameplayMode(GameplayMode.NEWGAME_STARTED);
-                    break;
-                case GAME_RESTARTING:
-                    game.changeGameplayMode(GameplayMode.GAME_RESTARTED);
-                    break;
-                case GAME_RESTARTED:
-                case NEWGAME_STARTED:
-                    game.getPlayfieldEl().removeReady();
-                    game.changeGameplayMode(GameplayMode.ORDINARY_PLAYING);
-                    break;
-                case GAMEOVER:
-                    game.getPlayfieldEl().removeGameover();
-                    break;
-                case LEVEL_BEING_COMPLETED:
-                    game.changeGameplayMode(GameplayMode.LEVEL_COMPLETED);
-                    break;
-                case LEVEL_COMPLETED:
-                    game.changeGameplayMode(GameplayMode.TRANSITION_INTO_NEXT_SCENE);
-                    break;
-                case TRANSITION_INTO_NEXT_SCENE:
-                    if (game.getLevelConfig().getCutsceneId() != 0) {
-                        game.setCutsceneId(game.getLevelConfig().getCutsceneId());
-                        game.changeGameplayMode(GameplayMode.CUTSCENE);
-                    } else {
-                        // canvasEl.style.visibility = "";
-                        game.getCanvasEl().setVisibility(true);
-                        game.newLevel(false);
-                    }
-                    break;
-                }
+                game.onGameplayModeTimerExpired();
             }
         }
     }

--- a/app/src/main/java/jp/or/iidukat/example/pacman/GameTimerManager.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GameTimerManager.java
@@ -19,6 +19,14 @@ class GameTimerManager {
         this.game = game;
     }
 
+    int getFrightModeTime() {
+        return frightModeTime;
+    }
+
+    void setFrightModeTime(int time) {
+        frightModeTime = time;
+    }
+
     void restartAll(LevelConfig levelConfig) {
         frightModeTime = 0;
         fruitTime = 0;

--- a/app/src/main/java/jp/or/iidukat/example/pacman/GameTimerManager.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GameTimerManager.java
@@ -32,7 +32,7 @@ class GameTimerManager {
     }
 
     void handleTimers() {
-        if (game.gameplayMode == GameplayMode.ORDINARY_PLAYING) {
+        if (game.getGameplayMode() == GameplayMode.ORDINARY_PLAYING) {
             handleForcePenLeaveTimer();
             handleFruitTimer();
             handleGhostModeTimer();
@@ -92,9 +92,9 @@ class GameTimerManager {
     }
 
     private void handleGameplayModeTimer() {
-        if (game.gameplayModeTime != 0) {
-            game.gameplayModeTime--;
-            switch (game.gameplayMode) {
+        if (game.getGameplayModeTime() != 0) {
+            game.decrementGameplayModeTime();
+            switch (game.getGameplayMode()) {
             case PLAYER_DYING:
             case PLAYER_DIED:
                 game.getPacman().updateAppearance();
@@ -104,14 +104,14 @@ class GameTimerManager {
                 }
                 break;
             case LEVEL_COMPLETED:
-                game.getPlayfieldEl().blink(game.gameplayModeTime, game.timing.levelCompleted);
+                game.getPlayfieldEl().blink(game.getGameplayModeTime(), game.getTiming().levelCompleted);
                 break;
             }
 
-            if (game.gameplayModeTime <= 0) {
-                game.gameplayModeTime = 0;
+            if (game.getGameplayModeTime() <= 0) {
+                game.resetGameplayModeTime();
                 Ghost[] ghosts = game.getGhosts();
-                switch (game.gameplayMode) {
+                switch (game.getGameplayMode()) {
                 case GHOST_DIED:
                     game.changeGameplayMode(GameplayMode.ORDINARY_PLAYING);
                     game.incrementGhostEyesCount();
@@ -161,11 +161,11 @@ class GameTimerManager {
                     break;
                 case TRANSITION_INTO_NEXT_SCENE:
                     if (game.getLevelConfig().getCutsceneId() != 0) {
-                        game.cutsceneId = game.getLevelConfig().getCutsceneId();
+                        game.setCutsceneId(game.getLevelConfig().getCutsceneId());
                         game.changeGameplayMode(GameplayMode.CUTSCENE);
                     } else {
                         // canvasEl.style.visibility = "";
-                        game.canvasEl.setVisibility(true);
+                        game.getCanvasEl().setVisibility(true);
                         game.newLevel(false);
                     }
                     break;

--- a/app/src/main/java/jp/or/iidukat/example/pacman/GhostModeController.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/GhostModeController.java
@@ -1,0 +1,146 @@
+package jp.or.iidukat.example.pacman;
+
+import jp.or.iidukat.example.pacman.entity.Ghost;
+import jp.or.iidukat.example.pacman.entity.Ghost.GhostMode;
+import jp.or.iidukat.example.pacman.entity.Pacman;
+
+class GhostModeController {
+
+    // Thresholds (dots eaten after a life loss) at which each ghost leaves the pen.
+    private static final int[] PEN_LEAVING_FOOD_LIMITS = { 0, 7, 17, 32 };
+
+    private final PacmanGame game;
+
+    GhostMode mainGhostMode;
+    GhostMode lastMainGhostMode;
+    private boolean alternatePenLeavingScheme;
+    private int alternateDotCount;
+    private double currentPlayerSpeed;
+    private double currentDotEatingSpeed;
+
+    GhostModeController(PacmanGame game) {
+        this.game = game;
+    }
+
+    GhostMode getMainGhostMode() { return mainGhostMode; }
+
+    GhostMode getLastMainGhostMode() { return lastMainGhostMode; }
+
+    void restartPenLeavingForNewLevel() {
+        alternatePenLeavingScheme = false;
+    }
+
+    void restartPenLeavingForNewLife() {
+        alternatePenLeavingScheme = true;
+        alternateDotCount = 0;
+    }
+
+    void switchMainGhostMode(GhostMode ghostMode, boolean justRestartGame) {
+        Ghost[] ghosts = game.getGhosts();
+        if (ghostMode == GhostMode.FRIGHTENED
+                && game.getLevelConfig().getFrightTime() == 0) {
+            for (Ghost ghost : ghosts) {
+                ghost.setReverseDirectionsNext(true); // If frightTime is 0, a frightened ghost only reverses its direction.
+            }
+        } else {
+            GhostMode oldMainGhostMode = mainGhostMode;
+            if (ghostMode == GhostMode.FRIGHTENED
+                    && mainGhostMode != GhostMode.FRIGHTENED) {
+                lastMainGhostMode = mainGhostMode;
+            }
+            mainGhostMode = ghostMode;
+            if (ghostMode == GhostMode.FRIGHTENED
+                || oldMainGhostMode == GhostMode.FRIGHTENED) {
+                game.playAmbientSound();
+            }
+            switch (ghostMode) {
+            case CHASE:
+            case SCATTER:
+                currentPlayerSpeed = game.getLevelConfig().getPlayerSpeed() * 0.8f;
+                currentDotEatingSpeed = game.getLevelConfig().getDotEatingSpeed() * 0.8f;
+                break;
+            case FRIGHTENED:
+                currentPlayerSpeed = game.getLevelConfig().getPlayerFrightSpeed() * 0.8f;
+                currentDotEatingSpeed = game.getLevelConfig().getDotEatingFrightSpeed() * 0.8f;
+                game.getGameTimerManager().setFrightModeTime(game.getLevelConfig().getFrightTotalTime());
+                game.resetModeScoreMultiplier();
+                break;
+            }
+            for (Ghost ghost : ghosts) {
+                if (ghostMode != GhostMode.ENTERING_PEN && !justRestartGame) {
+                    ghost.setModeChangedWhileInPen(true);
+                }
+                if (ghostMode == GhostMode.FRIGHTENED) {
+                    ghost.setEatenInThisFrightMode(false);
+                }
+                if (ghost.getMode() != GhostMode.EATEN
+                        && ghost.getMode() != GhostMode.IN_PEN
+                        && ghost.getMode() != GhostMode.LEAVING_PEN
+                        && ghost.getMode() != GhostMode.RE_LEAVING_FROM_PEN
+                        && ghost.getMode() != GhostMode.ENTERING_PEN || justRestartGame) {
+
+                    // If it is not immediately after restart the game (justRestartGame:false),
+                    // a ghost reverses its direction
+                    // when its mode changes from other than FRIGHTENED (CHASE or SCATTER) to another mode.
+                    if (!justRestartGame && ghost.getMode() != GhostMode.FRIGHTENED
+                            && ghost.getMode() != ghostMode) {
+                        ghost.setReverseDirectionsNext(true);
+                    }
+
+                    // If it is not immediately after restart the game
+                    // and a mode of each ghost is any of EATEN, IN_PEN, LEAVING_PEN, RE_LEAVING_FROM_PEN, or ENTERING_PEN,
+                    // it is not updated.
+                    ghost.switchGhostMode(ghostMode);
+                }
+            }
+
+            Pacman pacman = game.getPacman();
+            pacman.setFullSpeed(currentPlayerSpeed);
+            pacman.setDotEatingSpeed(currentDotEatingSpeed);
+            pacman.setTunnelSpeed(currentPlayerSpeed);
+            pacman.changeSpeed();
+        }
+    }
+
+    void figureOutPenLeaving() {
+        Ghost pinky = game.getPinky();
+        Ghost inky = game.getInky();
+        Ghost clyde = game.getClyde();
+        if (alternatePenLeavingScheme) {
+            // By using a number of dots eaten after a level restart,
+            // manage the timing of the ghosts leaving from the pen.
+            alternateDotCount++;
+            if (alternateDotCount == PEN_LEAVING_FOOD_LIMITS[1]) {
+                pinky.setFreeToLeavePen(true);
+            } else if (alternateDotCount == PEN_LEAVING_FOOD_LIMITS[2]) {
+                inky.setFreeToLeavePen(true);
+            } else if (alternateDotCount == PEN_LEAVING_FOOD_LIMITS[3]) {
+                if (clyde.getMode() == GhostMode.IN_PEN) {
+                    alternatePenLeavingScheme = false;
+                }
+            }
+        } else if (pinky.getMode() == GhostMode.IN_PEN
+                || pinky.getMode() == GhostMode.EATEN) {
+            pinky.incrementDotCount();
+            if (pinky.getDotCount() >= game.getLevelConfig().getPenLeavingLimits()[1]) {
+                pinky.setFreeToLeavePen(true);
+            }
+        } else if (inky.getMode() == GhostMode.IN_PEN
+                || inky.getMode() == GhostMode.EATEN) {
+            inky.incrementDotCount();
+            if (inky.getDotCount() >= game.getLevelConfig().getPenLeavingLimits()[2]) {
+                inky.setFreeToLeavePen(true);
+            }
+        } else if (clyde.getMode() == GhostMode.IN_PEN
+                || clyde.getMode() == GhostMode.EATEN) {
+            clyde.incrementDotCount();
+            if (clyde.getDotCount() >= game.getLevelConfig().getPenLeavingLimits()[3]) {
+                clyde.setFreeToLeavePen(true);
+            }
+        }
+    }
+
+    void finishFrightMode() {
+        switchMainGhostMode(lastMainGhostMode, false);
+    }
+}

--- a/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
@@ -9,12 +9,6 @@ import java.util.Map;
 
 import jp.or.iidukat.example.pacman.entity.PlayfieldActor;
 import jp.or.iidukat.example.pacman.entity.PlayfieldActor.CurrentSpeed;
-import jp.or.iidukat.example.pacman.entity.CutsceneActor;
-import jp.or.iidukat.example.pacman.entity.CutsceneBlinky;
-import jp.or.iidukat.example.pacman.entity.CutsceneField;
-import jp.or.iidukat.example.pacman.entity.CutscenePacman;
-import jp.or.iidukat.example.pacman.entity.CutsceneSteak;
-import jp.or.iidukat.example.pacman.entity.Entity;
 import jp.or.iidukat.example.pacman.entity.Fruit;
 import jp.or.iidukat.example.pacman.entity.Ghost;
 import jp.or.iidukat.example.pacman.entity.Ghost.GhostMode;
@@ -43,42 +37,6 @@ public class PacmanGame {
     // This is the thresholds of each ghost.
     private static final int[] PEN_LEAVING_FOOD_LIMITS = { 0, 7, 17, 32 };
 
-    // Cutscene Animation
-    private static class Cutscene {
-        private final Class<?>[] actors;
-        private final double[] sequenceTimes;
-
-        Cutscene(Class<?>[] actors, double[] sequenceTimes) {
-            this.actors = actors;
-            this.sequenceTimes = sequenceTimes;
-        }
-    }
-
-    private static final Map<Integer, Cutscene> CUTSCENES;
-    static {
-        Map<Integer, Cutscene> css = new HashMap<Integer, Cutscene>();
-        css.put(
-            Integer.valueOf(1),
-            new Cutscene(
-                new Class<?>[] { CutscenePacman.class, CutsceneBlinky.class },
-                new double[] { 5.5f, 0.1f, 9 }));
-        css.put(
-            Integer.valueOf(2),
-            new Cutscene(
-                new Class<?>[] {
-                    CutscenePacman.class,
-                    CutsceneBlinky.class,
-                    CutsceneSteak.class
-                },
-                new double[] { 2.7f, 1, 1.3f, 1, 2.5f }));
-        css.put(
-            Integer.valueOf(3),
-            new Cutscene(
-                new Class<?>[] { CutscenePacman.class, CutsceneBlinky.class },
-                new double[] { 5.3f, 5.3f }));
-        CUTSCENES = Collections.unmodifiableMap(css);
-    }
-    
     public static enum GameplayMode {
         ORDINARY_PLAYING(0), GHOST_DIED(1), PLAYER_DYING(2), PLAYER_DIED(3),
         NEWGAME_STARTING(4), NEWGAME_STARTED(5), GAME_RESTARTING(6), GAME_RESTARTED(7),
@@ -103,6 +61,7 @@ public class PacmanGame {
     SoundManager soundManager;
     private InputHandler inputHandler;
     GameTimerManager gameTimerManager;
+    CutsceneController cutsceneController;
 
     private boolean paused;
     private boolean started;
@@ -141,18 +100,12 @@ public class PacmanGame {
     private boolean fruitShown;
     private Ghost ghostBeingEaten;
 
-    private Cutscene cutscene;
-    int cutsceneId;
-    private int cutsceneSequenceId;
-    private double cutsceneTime;
-    private int debugCutsceneId;
-    private boolean debugCutsceneMode;
-    private Runnable onDebugCutsceneFinished;
     private TickClock tickClock;
 
     PacmanGame(Context context) {
         this.context = context;
         gameTimerManager = new GameTimerManager(this);
+        cutsceneController = new CutsceneController(this);
     }
 
     public double rand() {
@@ -236,9 +189,8 @@ public class PacmanGame {
         }
         soundManager.resetDotEatingSound();
 
-        if (newGame && debugCutsceneId != 0) {
-            cutsceneId = debugCutsceneId;
-            debugCutsceneId = 0;
+        if (newGame && cutsceneController.hasDebugCutscene()) {
+            cutsceneController.consumeDebugCutscene();
             changeGameplayMode(GameplayMode.CUTSCENE);
         } else if (newGame) {
             changeGameplayMode(GameplayMode.NEWGAME_STARTING);
@@ -319,7 +271,7 @@ public class PacmanGame {
             case FRIGHTENED:
                 currentPlayerSpeed = levelConfig.getPlayerFrightSpeed() * 0.8f;
                 currentDotEatingSpeed = levelConfig.getDotEatingFrightSpeed() * 0.8f;
-                gameTimerManager.frightModeTime = levelConfig.getFrightTotalTime();
+                gameTimerManager.setFrightModeTime(levelConfig.getFrightTotalTime());
                 modeScoreMultiplier = 1;
                 break;
             }
@@ -642,7 +594,7 @@ public class PacmanGame {
         case GHOST_DIED:
             break;
         case CUTSCENE:
-            startCutscene();
+            cutsceneController.start();
             break;
         }
     }
@@ -674,71 +626,6 @@ public class PacmanGame {
         } else {
             soundEl.setVisibility(false);
         }
-    }
-
-    private void startCutscene() {
-        getPlayfieldEl().setVisibility(false);
-        
-        canvasEl.setVisibility(true);
-        canvasEl.showChrome(false);
-        canvasEl.createCutsceneField();
-        
-        cutscene = CUTSCENES.get(Integer.valueOf(cutsceneId));
-        cutsceneSequenceId = -1;
-        gameTimerManager.frightModeTime = levelConfig.getFrightTotalTime();
-        createCutsceneActors();
-        
-        cutsceneNextSequence();
-        soundManager.stopAll();
-        soundManager.playCutsceneAmbient();
-    }
-    
-    private void createCutsceneActors() {
-        getCutsceneFieldEl().createActors(this, cutsceneId, cutscene.actors);
-    }
-
-    private void stopCutscene() {
-        soundManager.stopCutsceneAmbient();
-        getPlayfieldEl().setVisibility(true);
-        canvasEl.removeCutsceneField();
-        canvasEl.showChrome(true);
-        if (debugCutsceneMode) {
-            debugCutsceneMode = false;
-            if (onDebugCutsceneFinished != null) {
-                onDebugCutsceneFinished.run();
-            }
-        } else {
-            newLevel(false);
-        }
-    }
-
-    private void cutsceneNextSequence() {
-        cutsceneSequenceId++;
-        if (cutscene.sequenceTimes.length == cutsceneSequenceId) {
-            stopCutscene();
-        } else {
-            cutsceneTime = cutscene.sequenceTimes[cutsceneSequenceId] * GameConstants.DEFAULT_FPS;
-            CutsceneActor[] cutsceneActors = getCutsceneActors();
-            for (int i = 0; i < cutsceneActors.length; i++) {
-                CutsceneActor actor = cutsceneActors[i];
-                actor.setupSequence();
-                actor.updateAppearance();
-            }
-        }
-    }
-
-    private void checkCutscene() {
-        if (cutsceneTime <= 0) {
-            cutsceneNextSequence();
-        }
-    }
-
-    private void advanceCutscene() {
-        CutsceneActor[] cutsceneActors = getCutsceneActors();
-        for (CutsceneActor actor : cutsceneActors) {
-            actor.move();
-        }
-        cutsceneTime--;
     }
 
     private void updateActorPositions() {
@@ -776,11 +663,11 @@ public class PacmanGame {
         if (gameplayMode == GameplayMode.CUTSCENE) { // Cutscene
             for (int i = 0; i < tickClock.tickMultiplier + latencyMultiplyer; i++) {
                 // run multiple time depending on the tickMultiplier and latency
-                advanceCutscene();
+                cutsceneController.advance();
                 intervalTime = (intervalTime + 1) % GameConstants.DEFAULT_FPS;
                 globalTime++;
             }
-            checkCutscene();
+            cutsceneController.check();
             blinkScoreLabels();
         } else {
             updateSoundIcon();
@@ -901,14 +788,13 @@ public class PacmanGame {
     }
 
     void showCutscene(int id) {
-        debugCutsceneId = id;
-        debugCutsceneMode = true;
+        cutsceneController.setDebugCutsceneId(id);
         setDefaultKillScreenLevel();
         start();
     }
 
     void setOnDebugCutsceneFinished(Runnable callback) {
-        this.onDebugCutsceneFinished = callback;
+        cutsceneController.setOnFinished(callback);
     }
 
     private void setKillScreenLevel(int level) {
@@ -1051,22 +937,12 @@ public class PacmanGame {
         return playfieldEl.getDoor();
     }
 
-    private CutsceneField getCutsceneFieldEl() {
-        if (canvasEl == null) {
-            return null;
-        }
-        return canvasEl.getCutsceneField();
+    SoundManager getSoundManager() {
+        return soundManager;
     }
-    
-    private CutsceneActor[] getCutsceneActors() {
-        if (canvasEl == null) {
-            return null;
-        }
-        CutsceneField cutsceneFieldEl = canvasEl.getCutsceneField();
-        if (cutsceneFieldEl == null) {
-            return null;
-        }
-        return cutsceneFieldEl.getActors();
+
+    GameTimerManager getGameTimerManager() {
+        return gameTimerManager;
     }
 
     public boolean isPacManSound() {
@@ -1086,7 +962,7 @@ public class PacmanGame {
     }
 
     public int getFrightModeTime() {
-        return gameTimerManager.frightModeTime;
+        return gameTimerManager.getFrightModeTime();
     }
 
     public int getIntervalTime() {
@@ -1166,19 +1042,19 @@ public class PacmanGame {
     }
 
     public int getCutsceneId() {
-        return cutsceneId;
+        return cutsceneController.getCutsceneId();
     }
 
     void setCutsceneId(int cutsceneId) {
-        this.cutsceneId = cutsceneId;
+        cutsceneController.setCutsceneId(cutsceneId);
     }
 
     public int getCutsceneSequenceId() {
-        return cutsceneSequenceId;
+        return cutsceneController.getCutsceneSequenceId();
     }
 
     public double getCutsceneTime() {
-        return cutsceneTime;
+        return cutsceneController.getCutsceneTime();
     }
 
     public void setTilesChanged(boolean tilesChanged) {

--- a/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
@@ -539,6 +539,68 @@ public class PacmanGame {
         gameTimerManager.handleTimers();
     }
 
+    void onGameplayModeTimerExpired() {
+        Ghost[] ghosts = getGhosts();
+        switch (gameplayMode) {
+        case GHOST_DIED:
+            changeGameplayMode(GameplayMode.ORDINARY_PLAYING);
+            incrementGhostEyesCount();
+            playAmbientSound();
+            ghostBeingEaten.resetDisplayOrder();
+            ghostBeingEaten.switchGhostMode(GhostMode.EATEN);
+            // If there is no ghost frightened, finish fright mode.
+            boolean frightenedGhostExists = false;
+            for (Ghost ghost : ghosts) {
+                if (ghost.getMode() == GhostMode.FRIGHTENED
+                    || (ghost.getMode() == GhostMode.IN_PEN
+                            || ghost.getMode() == GhostMode.RE_LEAVING_FROM_PEN)
+                        && !ghost.isEatenInThisFrightMode()) {
+                    frightenedGhostExists = true;
+                    break;
+                }
+            }
+            if (!frightenedGhostExists) {
+                finishFrightMode();
+            }
+            break;
+        case PLAYER_DYING:
+            changeGameplayMode(GameplayMode.PLAYER_DIED);
+            break;
+        case PLAYER_DIED:
+            newLife();
+            break;
+        case NEWGAME_STARTING:
+            changeGameplayMode(GameplayMode.NEWGAME_STARTED);
+            break;
+        case GAME_RESTARTING:
+            changeGameplayMode(GameplayMode.GAME_RESTARTED);
+            break;
+        case GAME_RESTARTED:
+        case NEWGAME_STARTED:
+            getPlayfieldEl().removeReady();
+            changeGameplayMode(GameplayMode.ORDINARY_PLAYING);
+            break;
+        case GAMEOVER:
+            getPlayfieldEl().removeGameover();
+            break;
+        case LEVEL_BEING_COMPLETED:
+            changeGameplayMode(GameplayMode.LEVEL_COMPLETED);
+            break;
+        case LEVEL_COMPLETED:
+            changeGameplayMode(GameplayMode.TRANSITION_INTO_NEXT_SCENE);
+            break;
+        case TRANSITION_INTO_NEXT_SCENE:
+            if (levelConfig.getCutsceneId() != 0) {
+                cutsceneController.setCutsceneId(levelConfig.getCutsceneId());
+                changeGameplayMode(GameplayMode.CUTSCENE);
+            } else {
+                canvasEl.setVisibility(true);
+                newLevel(false);
+            }
+            break;
+        }
+    }
+
     void tick() {
         long now = new Date().getTime();
         if (paused) {

--- a/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
@@ -1097,6 +1097,14 @@ public class PacmanGame {
         return gameplayModeTime;
     }
 
+    void decrementGameplayModeTime() {
+        gameplayModeTime--;
+    }
+
+    void resetGameplayModeTime() {
+        gameplayModeTime = 0;
+    }
+
     Timing getTiming() {
         return timing;
     }
@@ -1159,6 +1167,10 @@ public class PacmanGame {
 
     public int getCutsceneId() {
         return cutsceneId;
+    }
+
+    void setCutsceneId(int cutsceneId) {
+        this.cutsceneId = cutsceneId;
     }
 
     public int getCutsceneSequenceId() {

--- a/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
@@ -32,11 +32,6 @@ public class PacmanGame {
 
     private static final int DEFAULT_KILL_SCREEN_LEVEL = 256;
     
-    // After a level restart, when a number of dots eaten by the player has reached the threshold,
-    // each ghost leaves from the pen.
-    // This is the thresholds of each ghost.
-    private static final int[] PEN_LEAVING_FOOD_LIMITS = { 0, 7, 17, 32 };
-
     public static enum GameplayMode {
         ORDINARY_PLAYING(0), GHOST_DIED(1), PLAYER_DYING(2), PLAYER_DIED(3),
         NEWGAME_STARTING(4), NEWGAME_STARTED(5), GAME_RESTARTING(6), GAME_RESTARTED(7),
@@ -62,6 +57,7 @@ public class PacmanGame {
     private InputHandler inputHandler;
     GameTimerManager gameTimerManager;
     CutsceneController cutsceneController;
+    GhostModeController ghostModeController;
 
     private boolean paused;
     private boolean started;
@@ -84,15 +80,8 @@ public class PacmanGame {
     private boolean tilesChanged = false;
     GameplayMode gameplayMode;
     Timing timing;
-    private boolean alternatePenLeavingScheme;
-    private int alternateDotCount;
     private boolean lostLifeOnThisLevel;
 
-    private GhostMode lastMainGhostMode;
-    GhostMode mainGhostMode;
-
-    private double currentPlayerSpeed;
-    private double currentDotEatingSpeed;
     private double cruiseElroySpeed;
     private Map<Double, Boolean[]> speedIntervals;
 
@@ -106,6 +95,7 @@ public class PacmanGame {
         this.context = context;
         gameTimerManager = new GameTimerManager(this);
         cutsceneController = new CutsceneController(this);
+        ghostModeController = new GhostModeController(this);
     }
 
     public double rand() {
@@ -219,7 +209,7 @@ public class PacmanGame {
             level >= LevelConfig.LEVEL_CONFIGS.length
                 ? LevelConfig.LEVEL_CONFIGS[LevelConfig.LEVEL_CONFIGS.length - 1]
                 : LevelConfig.LEVEL_CONFIGS[level];
-        alternatePenLeavingScheme = false;
+        ghostModeController.restartPenLeavingForNewLevel();
         lostLifeOnThisLevel = false;
         updateChrome();
         resetPlayfield();
@@ -231,8 +221,7 @@ public class PacmanGame {
 
     void newLife() {
         lostLifeOnThisLevel = true;
-        alternatePenLeavingScheme = true;
-        alternateDotCount = 0;
+        ghostModeController.restartPenLeavingForNewLife();
         lives--;
         updateChromeLives();
 
@@ -243,110 +232,8 @@ public class PacmanGame {
         }
     }
 
-    void switchMainGhostMode(GhostMode ghostMode,
-                                    boolean justRestartGame) {
-        Ghost[] ghosts = getGhosts();
-        if (ghostMode == GhostMode.FRIGHTENED
-                && levelConfig.getFrightTime() == 0) {
-            for (Ghost ghost : ghosts) {
-                ghost.setReverseDirectionsNext(true); // If frightTime is 0, a frightened ghost only reverse its direction.
-            }
-        } else {
-            GhostMode oldMainGhostMode = mainGhostMode;
-            if (ghostMode == GhostMode.FRIGHTENED
-                    && mainGhostMode != GhostMode.FRIGHTENED) {
-                lastMainGhostMode = mainGhostMode;
-            }
-            mainGhostMode = ghostMode;
-            if (ghostMode == GhostMode.FRIGHTENED
-                || oldMainGhostMode == GhostMode.FRIGHTENED) {
-                playAmbientSound();
-            }
-            switch (ghostMode) {
-            case CHASE:
-            case SCATTER:
-                currentPlayerSpeed = levelConfig.getPlayerSpeed() * 0.8f;
-                currentDotEatingSpeed = levelConfig.getDotEatingSpeed() * 0.8f;
-                break;
-            case FRIGHTENED:
-                currentPlayerSpeed = levelConfig.getPlayerFrightSpeed() * 0.8f;
-                currentDotEatingSpeed = levelConfig.getDotEatingFrightSpeed() * 0.8f;
-                gameTimerManager.setFrightModeTime(levelConfig.getFrightTotalTime());
-                modeScoreMultiplier = 1;
-                break;
-            }
-            for (Ghost ghost : ghosts) {
-                if (ghostMode != GhostMode.ENTERING_PEN && !justRestartGame) {
-                    ghost.setModeChangedWhileInPen(true);
-                }
-                if (ghostMode == GhostMode.FRIGHTENED) {
-                    ghost.setEatenInThisFrightMode(false);
-                }
-                if (ghost.getMode() != GhostMode.EATEN
-                        && ghost.getMode() != GhostMode.IN_PEN
-                        && ghost.getMode() != GhostMode.LEAVING_PEN
-                        && ghost.getMode() != GhostMode.RE_LEAVING_FROM_PEN
-                        && ghost.getMode() != GhostMode.ENTERING_PEN || justRestartGame) {
-
-                    // If it is not immediately after restart the game (justRestartGmae:false),
-                    // a ghost reverse its direction 
-                    // when its mode change from other than FRIGHTENED (CHASE or SCATTER) to another mode.
-                    if (!justRestartGame && ghost.getMode() != GhostMode.FRIGHTENED
-                            && ghost.getMode() != ghostMode) {
-                        ghost.setReverseDirectionsNext(true);
-                    }
-
-                    // If it is not immediately after restart the game
-                    // and a mode of each ghost is any of EATEN, IN_PEN, LEAVING_PEN, RE_LEAVING_FROM_PEN, or ENTERING_PEN,
-                    // it is not updated.
-                    ghost.switchGhostMode(ghostMode);
-                }
-            }
-
-            Pacman pacman = getPacman();
-            pacman.setFullSpeed(currentPlayerSpeed);
-            pacman.setDotEatingSpeed(currentDotEatingSpeed);
-            pacman.setTunnelSpeed(currentPlayerSpeed);
-            pacman.changeSpeed();
-        }
-    }
-
-    private void figureOutPenLeaving() {
-        Ghost pinky = getPinky();
-        Ghost inky = getInky();
-        Ghost clyde = getClyde();
-        if (alternatePenLeavingScheme) {
-            // By using a number of dots eaten after a level restart,
-            // manage the timing of the ghosts leaving from the pen.
-            alternateDotCount++;
-            if (alternateDotCount == PEN_LEAVING_FOOD_LIMITS[1]) {
-                pinky.setFreeToLeavePen(true);
-            } else if (alternateDotCount == PEN_LEAVING_FOOD_LIMITS[2]) {
-                inky.setFreeToLeavePen(true);
-            } else if (alternateDotCount == PEN_LEAVING_FOOD_LIMITS[3]) {
-                if (clyde.getMode() == GhostMode.IN_PEN) {
-                    alternatePenLeavingScheme = false;
-                }
-            }
-        } else if (pinky.getMode() == GhostMode.IN_PEN
-                || pinky.getMode() == GhostMode.EATEN) {
-            pinky.incrementDotCount();
-            if (pinky.getDotCount() >= levelConfig.getPenLeavingLimits()[1]) {
-                pinky.setFreeToLeavePen(true);
-            }
-        } else if (inky.getMode() == GhostMode.IN_PEN
-                || inky.getMode() == GhostMode.EATEN) {
-            inky.incrementDotCount();
-            if (inky.getDotCount() >= levelConfig.getPenLeavingLimits()[2]) {
-                inky.setFreeToLeavePen(true);
-            }
-        } else if (clyde.getMode() == GhostMode.IN_PEN
-                || clyde.getMode() == GhostMode.EATEN) {
-            clyde.incrementDotCount();
-            if (clyde.getDotCount() >= levelConfig.getPenLeavingLimits()[3]) {
-                clyde.setFreeToLeavePen(true);
-            }
-        }
+    void switchMainGhostMode(GhostMode ghostMode, boolean justRestartGame) {
+        ghostModeController.switchMainGhostMode(ghostMode, justRestartGame);
     }
 
     public void dotEaten(int[] dotPos) {
@@ -364,7 +251,7 @@ public class PacmanGame {
         getPlayfieldEl().clearDot(dotPos[1], dotPos[0]);
         updateCruiseElroySpeed();
         gameTimerManager.resetForcePenLeaveTime();
-        figureOutPenLeaving();
+        ghostModeController.figureOutPenLeaving();
         if (getPlayfieldEl().getDotsEaten() == 70
                 || getPlayfieldEl().getDotsEaten() == 170) {
             showFruit();
@@ -645,7 +532,7 @@ public class PacmanGame {
     }
 
     void finishFrightMode() {
-        switchMainGhostMode(lastMainGhostMode, false);
+        ghostModeController.finishFrightMode();
     }
 
     void handleTimers() {
@@ -746,7 +633,7 @@ public class PacmanGame {
             Playfield playfieldEl = getPlayfieldEl();
             ambient = ghostEyesCount != 0
                     ? "ambient_eyes"
-                    : mainGhostMode == GhostMode.FRIGHTENED
+                    : ghostModeController.getMainGhostMode() == GhostMode.FRIGHTENED
                         ? "ambient_fright"
                         : playfieldEl.getDotsEaten() > 241
                             ? "ambient_4"
@@ -998,11 +885,15 @@ public class PacmanGame {
     }
 
     public GhostMode getMainGhostMode() {
-        return mainGhostMode;
+        return ghostModeController.getMainGhostMode();
     }
 
     public GhostMode getLastMainGhostMode() {
-        return lastMainGhostMode;
+        return ghostModeController.getLastMainGhostMode();
+    }
+
+    void resetModeScoreMultiplier() {
+        modeScoreMultiplier = 1;
     }
 
     public Ghost getGhostBeingEaten() {

--- a/app/src/test/java/jp/or/iidukat/example/pacman/GameTimerManagerTest.java
+++ b/app/src/test/java/jp/or/iidukat/example/pacman/GameTimerManagerTest.java
@@ -22,8 +22,8 @@ public class GameTimerManagerTest {
     private PacmanGame mockGame;
     private GameTimerManager newManager() {
         mockGame = mock(PacmanGame.class);
-        mockGame.gameplayMode = GameplayMode.ORDINARY_PLAYING;
-        mockGame.gameplayModeTime = 0;
+        when(mockGame.getGameplayMode()).thenReturn(GameplayMode.ORDINARY_PLAYING);
+        when(mockGame.getGameplayModeTime()).thenReturn(0.0);
         return new GameTimerManager(mockGame);
     }
 
@@ -35,8 +35,8 @@ public class GameTimerManagerTest {
     @Test
     public void handleTimers_newgameStarting_expiresIntoNewgameStarted() {
         GameTimerManager tm = newManager();
-        mockGame.gameplayMode = GameplayMode.NEWGAME_STARTING;
-        mockGame.gameplayModeTime = 1;
+        when(mockGame.getGameplayMode()).thenReturn(GameplayMode.NEWGAME_STARTING);
+        when(mockGame.getGameplayModeTime()).thenReturn(1.0, 0.0);
 
         tm.handleTimers();
 
@@ -46,8 +46,8 @@ public class GameTimerManagerTest {
     @Test
     public void handleTimers_gameRestarting_expiresIntoGameRestarted() {
         GameTimerManager tm = newManager();
-        mockGame.gameplayMode = GameplayMode.GAME_RESTARTING;
-        mockGame.gameplayModeTime = 1;
+        when(mockGame.getGameplayMode()).thenReturn(GameplayMode.GAME_RESTARTING);
+        when(mockGame.getGameplayModeTime()).thenReturn(1.0, 0.0);
 
         tm.handleTimers();
 
@@ -57,8 +57,8 @@ public class GameTimerManagerTest {
     @Test
     public void handleTimers_levelBeingCompleted_expiresIntoLevelCompleted() {
         GameTimerManager tm = newManager();
-        mockGame.gameplayMode = GameplayMode.LEVEL_BEING_COMPLETED;
-        mockGame.gameplayModeTime = 1;
+        when(mockGame.getGameplayMode()).thenReturn(GameplayMode.LEVEL_BEING_COMPLETED);
+        when(mockGame.getGameplayModeTime()).thenReturn(1.0, 0.0);
 
         tm.handleTimers();
 
@@ -68,23 +68,23 @@ public class GameTimerManagerTest {
     @Test
     public void handleTimers_gameplayModeTime_decrementsEachTick() {
         GameTimerManager tm = newManager();
-        mockGame.gameplayMode = GameplayMode.GAME_RESTARTING;
-        mockGame.gameplayModeTime = 5;
+        when(mockGame.getGameplayMode()).thenReturn(GameplayMode.GAME_RESTARTING);
+        when(mockGame.getGameplayModeTime()).thenReturn(5.0);
 
         tm.handleTimers();
 
-        assertEquals(4.0, mockGame.gameplayModeTime, 1e-9);
+        verify(mockGame).decrementGameplayModeTime();
     }
 
     @Test
     public void handleTimers_zeroTime_doesNotDecrementOrTransition() {
         GameTimerManager tm = newManager();
-        mockGame.gameplayMode = GameplayMode.GAME_RESTARTING;
-        mockGame.gameplayModeTime = 0;
+        when(mockGame.getGameplayMode()).thenReturn(GameplayMode.GAME_RESTARTING);
+        when(mockGame.getGameplayModeTime()).thenReturn(0.0);
 
         tm.handleTimers();
 
-        assertEquals(0.0, mockGame.gameplayModeTime, 1e-9);
+        verify(mockGame, never()).decrementGameplayModeTime();
         verify(mockGame, never()).changeGameplayMode(any());
     }
 

--- a/app/src/test/java/jp/or/iidukat/example/pacman/GameTimerManagerTest.java
+++ b/app/src/test/java/jp/or/iidukat/example/pacman/GameTimerManagerTest.java
@@ -7,7 +7,6 @@ import jp.or.iidukat.example.pacman.entity.Ghost.GhostMode;
 
 import static jp.or.iidukat.example.pacman.PacmanGame.GameplayMode;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -28,41 +27,19 @@ public class GameTimerManagerTest {
     }
 
     // -----------------------------------------------------------------------
-    // Gameplay mode timer — expiry calls changeGameplayMode with correct mode
-    // (resulting state is tested in PacmanGameTimerTest.applyModeState_*)
+    // Gameplay mode timer — expiry delegates to PacmanGame.onGameplayModeTimerExpired()
+    // (transition behavior is tested in PacmanGameTimerTest.onGameplayModeTimerExpired_*)
     // -----------------------------------------------------------------------
 
     @Test
-    public void handleTimers_newgameStarting_expiresIntoNewgameStarted() {
+    public void handleTimers_expiresGameplayModeTime_callsOnGameplayModeTimerExpired() {
         GameTimerManager tm = newManager();
         when(mockGame.getGameplayMode()).thenReturn(GameplayMode.NEWGAME_STARTING);
         when(mockGame.getGameplayModeTime()).thenReturn(1.0, 0.0);
 
         tm.handleTimers();
 
-        verify(mockGame).changeGameplayMode(GameplayMode.NEWGAME_STARTED);
-    }
-
-    @Test
-    public void handleTimers_gameRestarting_expiresIntoGameRestarted() {
-        GameTimerManager tm = newManager();
-        when(mockGame.getGameplayMode()).thenReturn(GameplayMode.GAME_RESTARTING);
-        when(mockGame.getGameplayModeTime()).thenReturn(1.0, 0.0);
-
-        tm.handleTimers();
-
-        verify(mockGame).changeGameplayMode(GameplayMode.GAME_RESTARTED);
-    }
-
-    @Test
-    public void handleTimers_levelBeingCompleted_expiresIntoLevelCompleted() {
-        GameTimerManager tm = newManager();
-        when(mockGame.getGameplayMode()).thenReturn(GameplayMode.LEVEL_BEING_COMPLETED);
-        when(mockGame.getGameplayModeTime()).thenReturn(1.0, 0.0);
-
-        tm.handleTimers();
-
-        verify(mockGame).changeGameplayMode(GameplayMode.LEVEL_COMPLETED);
+        verify(mockGame).onGameplayModeTimerExpired();
     }
 
     @Test
@@ -85,7 +62,7 @@ public class GameTimerManagerTest {
         tm.handleTimers();
 
         verify(mockGame, never()).decrementGameplayModeTime();
-        verify(mockGame, never()).changeGameplayMode(any());
+        verify(mockGame, never()).onGameplayModeTimerExpired();
     }
 
     // -----------------------------------------------------------------------

--- a/app/src/test/java/jp/or/iidukat/example/pacman/PacmanGameTimerTest.java
+++ b/app/src/test/java/jp/or/iidukat/example/pacman/PacmanGameTimerTest.java
@@ -142,4 +142,62 @@ public class PacmanGameTimerTest {
         assertEquals(42.0, g.getGameplayModeTime(), 1e-9);
     }
 
+    // -----------------------------------------------------------------------
+    // onGameplayModeTimerExpired — pure mode transitions (no side-effects beyond changeGameplayMode)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Suppresses applyModeEffects so onGameplayModeTimerExpired can be tested
+     * without a fully initialised canvasEl.
+     */
+    private static class NoEffectsGame extends PacmanGame {
+        NoEffectsGame() { super(null); }
+        @Override void applyModeEffects(GameplayMode mode) {}
+    }
+
+    @Test
+    public void onGameplayModeTimerExpired_playerDying_transitionsToPlayerDied() {
+        NoEffectsGame g = new NoEffectsGame();
+        g.timing = new Timing(false);
+        g.gameplayMode = GameplayMode.PLAYER_DYING;
+        g.onGameplayModeTimerExpired();
+        assertEquals(GameplayMode.PLAYER_DIED, g.getGameplayMode());
+    }
+
+    @Test
+    public void onGameplayModeTimerExpired_newgameStarting_transitionsToNewgameStarted() {
+        NoEffectsGame g = new NoEffectsGame();
+        g.timing = new Timing(false);
+        g.gameplayMode = GameplayMode.NEWGAME_STARTING;
+        g.onGameplayModeTimerExpired();
+        assertEquals(GameplayMode.NEWGAME_STARTED, g.getGameplayMode());
+    }
+
+    @Test
+    public void onGameplayModeTimerExpired_gameRestarting_transitionsToGameRestarted() {
+        NoEffectsGame g = new NoEffectsGame();
+        g.timing = new Timing(false);
+        g.gameplayMode = GameplayMode.GAME_RESTARTING;
+        g.onGameplayModeTimerExpired();
+        assertEquals(GameplayMode.GAME_RESTARTED, g.getGameplayMode());
+    }
+
+    @Test
+    public void onGameplayModeTimerExpired_levelBeingCompleted_transitionsToLevelCompleted() {
+        NoEffectsGame g = new NoEffectsGame();
+        g.timing = new Timing(false);
+        g.gameplayMode = GameplayMode.LEVEL_BEING_COMPLETED;
+        g.onGameplayModeTimerExpired();
+        assertEquals(GameplayMode.LEVEL_COMPLETED, g.getGameplayMode());
+    }
+
+    @Test
+    public void onGameplayModeTimerExpired_levelCompleted_transitionsToTransitionIntoNextScene() {
+        NoEffectsGame g = new NoEffectsGame();
+        g.timing = new Timing(false);
+        g.gameplayMode = GameplayMode.LEVEL_COMPLETED;
+        g.onGameplayModeTimerExpired();
+        assertEquals(GameplayMode.TRANSITION_INTO_NEXT_SCENE, g.getGameplayMode());
+    }
+
 }


### PR DESCRIPTION
## Summary

PacmanGame had grown to ~1187 lines with four mixed responsibilities. This PR extracts three dedicated controllers and fixes a responsibility leak into GameTimerManager.

- **Phase A**: Replace `GameTimerManager`'s 5 direct package-private field accesses on `PacmanGame` with proper accessor/mutator methods (`decrementGameplayModeTime`, `resetGameplayModeTime`, `setCutsceneId`)
- **Phase B**: Extract `CutsceneController` — moves the `Cutscene` inner class, `CUTSCENES` map, and all cutscene state/logic (~150 lines) out of `PacmanGame`
- **Phase C**: Extract `GhostModeController` — moves ghost-mode state (`mainGhostMode`, `lastMainGhostMode`), pen-leaving state, and the three methods (`switchMainGhostMode`, `figureOutPenLeaving`, `finishFrightMode`) out of `PacmanGame`
- **Phase D**: Move game mode transition logic out of `GameTimerManager.handleGameplayModeTimer()` into a new `PacmanGame.onGameplayModeTimerExpired()` method — `GameTimerManager` now only handles timer countdown and per-tick animation effects

**PacmanGame line count:** ~1187 → ~820 (after Phase D)

## Test plan

- [x] All existing unit tests pass (`./gradlew testDebugUnitTest`)
- [x] `GameTimerManagerTest`: updated to verify `onGameplayModeTimerExpired()` is called on timer expiry instead of verifying mode transitions directly
- [x] `PacmanGameTimerTest`: added 5 `onGameplayModeTimerExpired_*` tests for pure mode transitions using `NoEffectsGame` subclass

🤖 Generated with [Claude Code](https://claude.com/claude-code)