### PR TITLE
Add debug logging to diagnose intermittent BGM stop failure

### DIFF
--- a/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/PacmanGame.java
@@ -50,6 +50,8 @@ public class PacmanGame {
 
     }
 
+    private static final PacmanLogger LOG = new PacmanLogger("PacmanSound");
+
     private final Context context;
     GameView view;
     private Bitmap sourceImage;
@@ -440,6 +442,7 @@ public class PacmanGame {
             playAmbientSound();
             break;
         case PLAYER_DYING:
+            LOG.d(() -> "applyModeEffects: PLAYER_DYING -> stopAll()");
             soundManager.stopAll();
             break;
         case PLAYER_DIED:
@@ -689,7 +692,7 @@ public class PacmanGame {
     }
 
     public void playAmbientSound() {
-        String ambient = null;
+        final String ambient;
         if (gameplayMode == GameplayMode.ORDINARY_PLAYING
                 || gameplayMode == GameplayMode.GHOST_DIED) {
             Playfield playfieldEl = getPlayfieldEl();
@@ -703,7 +706,10 @@ public class PacmanGame {
                                 ? "ambient_3"
                                 : playfieldEl.getDotsEaten() > 138
                                     ? "ambient_2" : "ambient_1";
+        } else {
+            ambient = null;
         }
+        LOG.d(() -> "playAmbientSound: mode=" + gameplayMode + " ambient=" + ambient);
         soundManager.playAmbient(ambient);
     }
 

--- a/app/src/main/java/jp/or/iidukat/example/pacman/PacmanLogger.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/PacmanLogger.java
@@ -1,0 +1,49 @@
+package jp.or.iidukat.example.pacman;
+
+import android.util.Log;
+
+import java.util.function.Supplier;
+
+class PacmanLogger {
+
+    interface Backend {
+        boolean isLoggable(String tag, int level);
+        void log(int level, String tag, String msg);
+    }
+
+    private static final Backend ANDROID = new Backend() {
+        @Override
+        public boolean isLoggable(String tag, int level) {
+            return Log.isLoggable(tag, level);
+        }
+
+        @Override
+        public void log(int level, String tag, String msg) {
+            Log.println(level, tag, msg);
+        }
+    };
+
+    private final String tag;
+    private final Backend backend;
+
+    PacmanLogger(String tag) {
+        this(tag, ANDROID);
+    }
+
+    PacmanLogger(String tag, Backend backend) {
+        this.tag = tag;
+        this.backend = backend;
+    }
+
+    void d(Supplier<String> msg) {
+        if (backend.isLoggable(tag, Log.DEBUG)) {
+            backend.log(Log.DEBUG, tag, msg.get());
+        }
+    }
+
+    void w(Supplier<String> msg) {
+        if (backend.isLoggable(tag, Log.WARN)) {
+            backend.log(Log.WARN, tag, msg.get());
+        }
+    }
+}

--- a/app/src/main/java/jp/or/iidukat/example/pacman/SoundManager.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/SoundManager.java
@@ -1,8 +1,11 @@
 package jp.or.iidukat.example.pacman;
 
 import android.content.Context;
+import android.util.Log;
 
 class SoundManager {
+
+    private static final PacmanLogger LOG = new PacmanLogger("PacmanSound");
 
     private final Context context;
     private SoundPlayer soundPlayer;
@@ -54,11 +57,13 @@ class SoundManager {
     }
 
     void stopAmbient() {
+        LOG.d(() -> "stopAmbient: oldAmbient=" + oldAmbient);
         if (soundPlayer != null) soundPlayer.stopAmbient();
         oldAmbient = null;
     }
 
     void stopAll() {
+        LOG.d(() -> "stopAll: oldAmbient=" + oldAmbient + "\n" + Log.getStackTraceString(new Throwable()));
         stopAmbient();
         for (int i = 0; i < 5; i++) {
             stopChannel(i);
@@ -66,14 +71,26 @@ class SoundManager {
     }
 
     void playAmbient(String track) {
-        if (!pacManSound || soundPlayer == null || track == null) return;
-        if (track.equals(oldAmbient)) return;
+        if (track == null) {
+            LOG.d(() -> "playAmbient: skip (track=null) oldAmbient=" + oldAmbient);
+            return;
+        }
+        if (!pacManSound || soundPlayer == null) {
+            LOG.d(() -> "playAmbient: skip (pacManSound=" + pacManSound + " soundPlayer=null) track=" + track);
+            return;
+        }
+        if (track.equals(oldAmbient)) {
+            LOG.d(() -> "playAmbient: skip (dedup) track=" + track);
+            return;
+        }
+        LOG.d(() -> "playAmbient: PLAY track=" + track + " (was " + oldAmbient + ")");
         soundPlayer.playAmbient(track);
         oldAmbient = track;
     }
 
     // Resume the last ambient track after an Activity pause without dedup check.
     void resumeAmbient() {
+        LOG.d(() -> "resumeAmbient: oldAmbient=" + oldAmbient);
         if (pacManSound && soundPlayer != null && oldAmbient != null) {
             soundPlayer.playAmbient(oldAmbient);
         }

--- a/app/src/main/java/jp/or/iidukat/example/pacman/SoundManager.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/SoundManager.java
@@ -76,7 +76,7 @@ class SoundManager {
             return;
         }
         if (!pacManSound || soundPlayer == null) {
-            LOG.d(() -> "playAmbient: skip (pacManSound=" + pacManSound + " soundPlayer=null) track=" + track);
+            LOG.d(() -> "playAmbient: skip (pacManSound=" + pacManSound + " soundPlayerNull=" + (soundPlayer == null) + ") track=" + track);
             return;
         }
         if (track.equals(oldAmbient)) {

--- a/app/src/main/java/jp/or/iidukat/example/pacman/SoundPlayer.java
+++ b/app/src/main/java/jp/or/iidukat/example/pacman/SoundPlayer.java
@@ -13,6 +13,8 @@ import android.util.Log;
 class SoundPlayer {
 
     private static final String TAG = "SoundPlayer";
+    private static final PacmanLogger LOG = new PacmanLogger(TAG);
+
     private static final int[] SOUND_RESOURCES = {
         R.raw.death,
         R.raw.eating_dot_1,
@@ -33,7 +35,7 @@ class SoundPlayer {
     };
     private static final int AMBIENT_CHANNEL_COUNT = 1;
     private static final int CUTSCENE_RESOURCE_ID = R.raw.cutscene;
-    
+
     private final Context context;
     private SoundPoolManager soundManager;
     private boolean soundAvailable;
@@ -42,7 +44,7 @@ class SoundPlayer {
     private AudioClip cutsceneAudioClip;
     private boolean cutsceneAmbientAvailable;
     private String queuedAmbient;
-    
+
     SoundPlayer(Context context) {
         this.context = context;
     }
@@ -97,24 +99,30 @@ class SoundPlayer {
 
     void playAmbient(String track) {
         if (isAvailable()) {
+            LOG.d(() -> "playAmbient: play track=" + track);
             ambientManager.playTrack(track, 0, true);
             queuedAmbient = null;
         } else {
+            LOG.d(() -> "playAmbient: not available, queue track=" + track);
             queuedAmbient = track;
         }
     }
-    
+
     private void playQueuedAmbient() {
         if (queuedAmbient != null) {
+            LOG.d(() -> "playQueuedAmbient: play track=" + queuedAmbient);
             ambientManager.playTrack(queuedAmbient, 0, true);
             queuedAmbient = null;
         }
     }
 
     void stopAmbient() {
-       queuedAmbient = null;
+        LOG.d(() -> "stopAmbient: isAvailable=" + isAvailable() + " queuedAmbient=" + queuedAmbient);
+        queuedAmbient = null;
         if (isAvailable()) {
             ambientManager.stopChannel(0);
+        } else {
+            LOG.w(() -> "stopAmbient: NOT AVAILABLE — ambient channel not stopped!");
         }
     }
 
@@ -153,7 +161,7 @@ class SoundPlayer {
     }
 
     private static class SoundPoolManager {
-        
+
         private static interface AvailabilityNotifier {
             void notifyAvailability();
         }
@@ -209,7 +217,7 @@ class SoundPlayer {
                 soundPool.release();
                 soundPool = null;
             }
-            
+
             soundIds.clear();
             for (int i = 0; i < channels.length; i++) {
                 channels[i] = 0;
@@ -220,7 +228,7 @@ class SoundPlayer {
             if (soundPool == null) {
                 return;
             }
-            
+
             Integer id = soundIds.get(track);
             if (id == null) {
                 throw new IllegalArgumentException(
@@ -245,7 +253,7 @@ class SoundPlayer {
             if (soundPool == null) {
                 return;
             }
-            
+
             if (channel >= channels.length) {
                 throw new IllegalArgumentException(
                                 "channel is too large. : " + channel);


### PR DESCRIPTION
## Summary

- Introduce `PacmanLogger`: lazy `Supplier<String>` evaluation + swappable `Backend` interface (Android `Log` by default)
- Add `LOG.d()`/`LOG.w()` calls to `SoundManager`, `SoundPlayer`, and `PacmanGame` to trace sound lifecycle events

## Background

Intermittent bug where BGM doesn't stop when Pac-Man dies. Suspected causes:
- `SoundPlayer.stopAmbient()` skipping actual channel stop when `isAvailable() == false`
- Orphaned SoundPool streams after Activity pause/resume

## How to enable logs

```
adb shell setprop log.tag.PacmanSound DEBUG
adb shell setprop log.tag.SoundPlayer DEBUG
adb logcat -s PacmanSound SoundPlayer
```

## Test plan

- [x] Build succeeds
- [x] Play through several lives and verify BGM stops on death in logcat
- [x] Check for `NOT AVAILABLE` warning in `SoundPlayer.stopAmbient` when bug manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)